### PR TITLE
fix(build): Correct nest-cli.json configuration

### DIFF
--- a/nest-cli.json
+++ b/nest-cli.json
@@ -1,11 +1,9 @@
 {
   "$schema": "https://json.schemastore.org/nest-cli",
   "collection": "@nestjs/schematics",
-  "sourceRoot": "apps/cardano-backend/src",
   "compilerOptions": {
     "deleteOutDir": true,
-    "webpack": true,
-    "tsConfigPath": "apps/cardano-backend/tsconfig.app.json"
+    "webpack": true
   },
   "projects": {
     "api-gateway": {
@@ -63,6 +61,5 @@
       }
     }
   },
-  "monorepo": true,
-  "root": "apps/cardano-backend"
+  "monorepo": true
 }


### PR DESCRIPTION
Removed lingering references to the deleted default application scaffold from nest-cli.json to resolve build errors in the CI pipeline. The configuration now accurately reflects the active applications and libraries in the monorepo.
