### PR TITLE
feat: Simplify NFT metadata to vehicle number and PDF hash

### DIFF
--- a/src/blockchain/blockchain.service.ts
+++ b/src/blockchain/blockchain.service.ts
@@ -115,24 +115,6 @@ export class BlockchainService {
     this.logger.log(
       `Attempting to mint NFT for vehicle: ${metadata.vehicleNumber}`,
     );
-    // Basic validation of required metadata fields for minting
-    if (
-      !metadata.inspectionId ||
-      !metadata.inspectionDate ||
-      !metadata.vehicleNumber ||
-      !metadata.vehicleBrand ||
-      !metadata.vehicleModel ||
-      !metadata.vehicleYear ||
-      !metadata.vehicleColor ||
-      !metadata.overallRating ||
-      !metadata.pdfUrl ||
-      !metadata.pdfHash ||
-      !metadata.inspectorId
-    ) {
-      throw new BadRequestException(
-        'Missing required fields in metadata for NFT minting (inspectionId, inspectionDate, vehicleNumber, vehicleBrand, vehicleModel, overallRating, inspectorId, pdfUrl, pdfHash).',
-      );
-    }
 
     try {
       const utxos = await this.wallet.getUtxos();
@@ -151,13 +133,13 @@ export class BlockchainService {
       const policyId = resolveScriptHash(forgingScript); // Calculate the policy ID
 
       // Generate a unique token name based on key inspection data + perhaps a random element or timestamp for uniqueness assurance
-      const uniqueDataString = `${metadata.inspectionId}-${metadata.inspectionDate}-${metadata.vehicleNumber}`;
+      const uniqueDataString = `${metadata.vehicleNumber}`;
       const tokenName = this.generateTokenName(uniqueDataString);
       const tokenNameHex = stringToHex(tokenName); // Convert to hex for the blockchain
       const assetNameForMetadata = Buffer.from(tokenNameHex, 'hex').toString(
         'utf8',
       );
-      const simpleAssetName = `Inspection_${metadata.inspectionId}`;
+      const simpleAssetName = `Inspection_${metadata.vehicleNumber}`;
       const simpleAssetNameHex = stringToHex(simpleAssetName);
       // Construct the full asset ID
       const assetId = policyId + simpleAssetNameHex;

--- a/src/inspections/inspections.service.ts
+++ b/src/inspections/inspections.service.ts
@@ -818,22 +818,9 @@ export class InspectionsService {
       let blockchainSuccess = false;
 
       try {
-        // Siapkan metadata untuk NFT
-        // Explicitly type vehicleData as JsonObject for safe access
-        const vehicleData = inspection.vehicleData as Prisma.JsonObject | null;
-
         const metadataForNft: any = {
-          inspectionId: inspectionId,
-          inspectionDate: inspection.inspectionDate?.toISOString(), // Kirim ISO string
           vehicleNumber: inspection.vehiclePlateNumber,
-          vehicleBrand: vehicleData?.merekKendaraan ?? null, // Safe access
-          vehicleModel: vehicleData?.tipeKendaraan ?? null, // Safe access
-          vehicleYear: vehicleData?.tahun ?? null, // Safe access
-          vehicleColor: vehicleData?.warnaKendaraan ?? null, // Safe access
-          overallRating: inspection.overallRating,
-          pdfUrl: pdfPublicUrl, // URL ke PDF
-          pdfHash: pdfHashString, // Hash PDF
-          inspectorId: inspection.inspectorId,
+          pdfHash: pdfHashString,
         };
         // Hapus field null/undefined dari metadata jika perlu
         Object.keys(metadataForNft).forEach((key) =>


### PR DESCRIPTION
This commit streamlines the NFT metadata structure by removing all fields except for `vehicleNumber` and `pdfHash`.

The previous metadata contained a more extensive set of attributes, but for the current requirements, only the vehicle number and the hash of the associated PDF document are necessary. This simplification reduces the size of the metadata and makes it more focused on the essential information for verifying the NFT's core attributes.

The following changes were made to the metadata structure:

- Removed fields: [`inspectorId`, `inspectionDate`, `vehicleBrand`, `vehicleModel`, `vehicleYear`, `vehicleColor`, `overallRating`, `pdfUrl`, `inspectorId`]
- Retained fields: `vehicleNumber`, `pdfHash`

This change improves efficiency and clarity for systems interacting with this NFT metadata.