### PR TITLE
feat(auth): Add endpoint to check JWT token validity

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -228,6 +228,31 @@ export class AuthController {
     return user;
   }
 
+  /**
+   * Checks if the provided JWT token is valid and not expired.
+   * Requires a valid JWT in the Authorization header.
+   *
+   * @returns {object} A success message if the token is valid.
+   */
+  @Get('check-token')
+  @UseGuards(JwtAuthGuard) // Protect with JWT
+  @ApiBearerAuth('JwtAuthGuard') // Document requirement
+  @ApiOperation({ summary: 'Check if JWT token is valid' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Token is valid.',
+  })
+  @ApiResponse({
+    status: HttpStatus.UNAUTHORIZED,
+    description: 'Unauthorized (token is invalid or expired).',
+  })
+  checkTokenValidity(): { message: string } {
+    // If the JwtAuthGuard passes, the token is valid.
+    // The method body is only executed if the token is valid.
+    this.logger.log('Token validity check successful.');
+    return { message: 'Token is valid.' };
+  }
+
   // --- Placeholder Endpoints for Account Linking (Implement Later) ---
 
   // @Post('link/google')


### PR DESCRIPTION
Implement a new GET endpoint `/auth/check-token` in `AuthController`. This endpoint is protected by `JwtAuthGuard` and allows the frontend to verify if a user's JWT token is still valid and not expired.

If the token is valid, the endpoint returns a 200 OK response. If the token is invalid or expired, the `JwtAuthGuard` automatically handles the error and returns a 401 Unauthorized response.