### PR TITLE
feat(auth): Implement PIN login and refresh token mechanism

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   app:
     build: .

--- a/prisma/migrations/20250708141735_add_pin_and_refreshtoken_to_user/migration.sql
+++ b/prisma/migrations/20250708141735_add_pin_and_refreshtoken_to_user/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[refreshToken]` on the table `users` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "pin" TEXT,
+ADD COLUMN     "refreshToken" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "users_refreshToken_key" ON "users"("refreshToken");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -50,6 +50,8 @@ model User {
   email         String?   @unique // Optional: Required for Google/Email login, can be null for Wallet Login? (Needs to be validated in logic)
   username      String?   @unique // Optional: Required for Username/Password login? Can be null for Google/Wallet.
   password      String?   // Optional: Only exists (as HASH) if user registers/logins via Username/Email + Password. Null for Google/Wallet.
+  pin           String?   // PIN for inspector login
+  refreshToken  String?   @unique
   walletAddress String?   @unique // Optional: Only present if user login/link via Wallet. Must be unique if present.
   googleId      String?   @unique // Optional: Only present if the user logged in/linked via Google. Must be unique if present.
   role          Role      @default(CUSTOMER)

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -29,6 +29,9 @@ import { JwtAuthGuard } from './guards/jwt-auth.guard';
 import { RolesGuard } from './guards/roles.guard';
 import { LocalAuthGuard } from './guards/local-auth.guard';
 import { WalletAuthGuard } from './guards/wallet-auth.guard';
+import { ManualPinGuard } from './guards/manual-pin.guard';
+import { JwtRefreshStrategy } from './strategies/jwt-refresh.strategy';
+import { JwtRefreshGuard } from './guards/jwt-refresh.guard';
 
 /**
  * NestJS module responsible for managing authentication.
@@ -66,10 +69,13 @@ import { WalletAuthGuard } from './guards/wallet-auth.guard';
     JwtStrategy, // Register JWT Strategy
     WalletStrategy, // Register Wallet Strategy
     LocalStrategy, // Register Local Strategy
+    JwtRefreshStrategy, // Register JWT Refresh Strategy
     JwtAuthGuard, // Register JWT Guard as a provider so that it can be injected if necessary
     RolesGuard, // Register Roles Guard as a provider
     LocalAuthGuard, // Register Local Auth (username, email, password) Guard as a provider
     WalletAuthGuard, // Register Wallet Auth Guard as a provider
+    ManualPinGuard,
+    JwtRefreshGuard, // Register JWT Refresh Guard as a provider
   ],
   /**
    * Exports services and guards to be used by other modules.

--- a/src/auth/dto/login-inspector.dto.ts
+++ b/src/auth/dto/login-inspector.dto.ts
@@ -1,0 +1,23 @@
+/*
+ * --------------------------------------------------------------------------
+ * File: login-inspector.dto.ts
+ * Project: car-dano-backend
+ * Copyright © 2025 PT. Inspeksi Mobil Jogja
+ * --------------------------------------------------------------------------
+ * Description: DTO for inspector login requests using a PIN.
+ * --------------------------------------------------------------------------
+ */
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsNotEmpty, Length } from 'class-validator';
+
+export class LoginInspectorDto {
+  @ApiProperty({
+    description: "Inspector's unique 6-digit PIN",
+    example: '123456',
+    required: true,
+  })
+  @IsString()
+  @IsNotEmpty()
+  @Length(6, 6, { message: 'PIN must be exactly 6 digits' })
+  pin: string;
+}

--- a/src/auth/dto/login-response.dto.ts
+++ b/src/auth/dto/login-response.dto.ts
@@ -25,6 +25,15 @@ export class LoginResponseDto {
   accessToken: string;
 
   /**
+   * The JSON Web Token (JWT) used for refreshing the access token.
+   */
+  @ApiProperty({
+    description: 'JWT refresh token for refreshing the access token',
+    example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
+  })
+  refreshToken: string;
+
+  /**
    * Details of the authenticated user (excluding sensitive information).
    */
   @ApiProperty({

--- a/src/auth/guards/jwt-refresh.guard.ts
+++ b/src/auth/guards/jwt-refresh.guard.ts
@@ -1,0 +1,14 @@
+/*
+ * --------------------------------------------------------------------------
+ * File: jwt-refresh.guard.ts
+ * Project: car-dano-backend
+ * Copyright © 2025 PT. Inspeksi Mobil Jogja
+ * --------------------------------------------------------------------------
+ * Description: Auth guard for the JWT refresh strategy.
+ * --------------------------------------------------------------------------
+ */
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class JwtRefreshGuard extends AuthGuard('jwt-refresh') {}

--- a/src/auth/guards/manual-pin.guard.ts
+++ b/src/auth/guards/manual-pin.guard.ts
@@ -1,0 +1,36 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  UnauthorizedException,
+  Logger,
+} from '@nestjs/common';
+import { AuthService } from '../auth.service';
+
+@Injectable()
+export class ManualPinGuard implements CanActivate {
+  private readonly logger = new Logger(ManualPinGuard.name);
+
+  constructor(private readonly authService: AuthService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+    const { pin } = request.body;
+
+    if (!pin) {
+      this.logger.error(
+        'ManualPinGuard failed: No PIN provided in request body.',
+      );
+      throw new UnauthorizedException('PIN is required.');
+    }
+
+    const user = await this.authService.validateInspectorByPin(pin);
+
+    if (!user) {
+      this.logger.warn('ManualPinGuard validation failed: Invalid PIN.');
+      throw new UnauthorizedException('Invalid credentials.');
+    }
+    request.user = user; // Attach user to the request object
+    return true;
+  }
+}

--- a/src/auth/strategies/jwt-refresh.strategy.ts
+++ b/src/auth/strategies/jwt-refresh.strategy.ts
@@ -1,0 +1,61 @@
+/*
+ * --------------------------------------------------------------------------
+ * File: jwt-refresh.strategy.ts
+ * Project: car-dano-backend
+ * Copyright © 2025 PT. Inspeksi Mobil Jogja
+ * --------------------------------------------------------------------------
+ * Description: Implements the Passport.js strategy for validating JWT refresh tokens.
+ * --------------------------------------------------------------------------
+ */
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy, StrategyOptionsWithRequest } from 'passport-jwt';
+import { Request } from 'express';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { UsersService } from '../../users/users.service';
+import { JwtPayload } from '../interfaces/jwt-payload.interface';
+import * as bcrypt from 'bcrypt';
+
+@Injectable()
+export class JwtRefreshStrategy extends PassportStrategy(
+  Strategy,
+  'jwt-refresh',
+) {
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly usersService: UsersService,
+  ) {
+    const opts: StrategyOptionsWithRequest = {
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      secretOrKey: configService.getOrThrow<string>('JWT_REFRESH_SECRET'),
+      passReqToCallback: true,
+    };
+    super(opts);
+  }
+
+  async validate(req: Request, payload: JwtPayload) {
+    const refreshToken = req.get('Authorization')?.replace('Bearer', '').trim();
+
+    if (!refreshToken) {
+      throw new UnauthorizedException('Refresh token malformed');
+    }
+
+    const user = await this.usersService.findById(payload.sub);
+
+    if (!user || !user.refreshToken) {
+      throw new UnauthorizedException('Access Denied');
+    }
+
+    const isRefreshTokenMatching = await bcrypt.compare(
+      refreshToken,
+      user.refreshToken,
+    );
+
+    if (!isRefreshTokenMatching) {
+      throw new UnauthorizedException('Access Denied');
+    }
+
+    // The user object from the payload is returned, which will be attached to req.user
+    return user;
+  }
+}

--- a/src/inspections/inspections.controller.ts
+++ b/src/inspections/inspections.controller.ts
@@ -151,28 +151,40 @@ export class InspectionsController {
    */
   @Post()
   @HttpCode(HttpStatus.CREATED)
-  // @UseGuards(JwtAuthGuard, RolesGuard) // Apply guards later
-  // @Roles(Role.ADMIN, Role.REVIEWER, Role.INSPECTOR) // Define allowed roles later
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Role.INSPECTOR)
+  @ApiBearerAuth()
   @ApiOperation({
-    summary: 'Create a new inspection record',
+    summary: 'Create a new inspection record (Inspector only)',
     description:
-      'Creates the initial inspection record containing text and JSON data. This is the first step before uploading photos or archiving.',
+      'Creates the initial inspection record containing text and JSON data. This is the first step before uploading photos or archiving. Only accessible by users with the INSPECTOR role.',
   })
   @ApiBody({ type: CreateInspectionDto })
   @ApiResponse({
-    status: 201,
+    status: HttpStatus.CREATED,
     description: 'The newly created inspection record summary.',
     type: InspectionResponseDto,
   })
   @ApiResponse({
-    status: 400,
+    status: HttpStatus.BAD_REQUEST,
     description: 'Bad Request (e.g., invalid input data).',
+  })
+  @ApiResponse({
+    status: HttpStatus.UNAUTHORIZED,
+    description: 'Unauthorized. User is not authenticated.',
+  })
+  @ApiResponse({
+    status: HttpStatus.FORBIDDEN,
+    description: 'Forbidden. User does not have the INSPECTOR role.',
   })
   async create(
     @Body() createInspectionDto: CreateInspectionDto,
+    @GetUser('id') inspectorId: string,
   ): Promise<{ id: string }> {
-    const newInspection =
-      await this.inspectionsService.create(createInspectionDto);
+    const newInspection = await this.inspectionsService.create(
+      createInspectionDto,
+      inspectorId,
+    );
     return newInspection;
   }
 

--- a/src/inspections/inspections.service.ts
+++ b/src/inspections/inspections.service.ts
@@ -157,14 +157,14 @@ export class InspectionsService {
    */
   async create(
     createInspectionDto: CreateInspectionDto,
+    inspectorId: string,
   ): Promise<{ id: string }> {
     this.logger.log(
-      `Creating inspection for plate: ${createInspectionDto.vehiclePlateNumber ?? 'N/A'}`,
+      `Creating inspection for plate: ${createInspectionDto.vehiclePlateNumber ?? 'N/A'} by inspector ${inspectorId}`,
     );
 
     const { identityDetails } = createInspectionDto;
-    const inspectorUuid = identityDetails.namaInspektor; // This is now the UUID
-    const branchCityUuid = identityDetails.cabangInspeksi; // This is now the UUID
+    const branchCityUuid = identityDetails.cabangInspeksi;
     const customerName = identityDetails.namaCustomer;
 
     // 1. Fetch Inspector and Branch City records using UUIDs
@@ -174,12 +174,12 @@ export class InspectionsService {
 
     try {
       const inspector = await this.prisma.user.findUnique({
-        where: { id: inspectorUuid },
+        where: { id: inspectorId },
         select: { name: true },
       });
       if (!inspector) {
         throw new BadRequestException(
-          `Inspector with ID "${inspectorUuid}" not found.`,
+          `Inspector with ID "${inspectorId}" not found.`,
         );
       }
       inspectorName = inspector.name;
@@ -236,7 +236,7 @@ export class InspectionsService {
         const dataToCreate: Prisma.InspectionCreateInput = {
           pretty_id: customId,
           // Store the UUIDs in the dedicated ID fields
-          inspector: { connect: { id: inspectorUuid } }, // Connect using the UUID
+          inspector: { connect: { id: inspectorId } }, // Connect using the UUID
           branchCity: { connect: { id: branchCityUuid } }, // Connect using the UUID
 
           vehiclePlateNumber: createInspectionDto.vehiclePlateNumber,

--- a/src/users/dto/create-inspector.dto.ts
+++ b/src/users/dto/create-inspector.dto.ts
@@ -73,4 +73,14 @@ export class CreateInspectorDto {
   @IsOptional()
   @IsString()
   walletAddress?: string;
+
+  @ApiProperty({
+    description: 'Optional PIN for the inspector (6 digits)',
+    example: '123456',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  @MinLength(6)
+  pin?: string;
 }

--- a/src/users/dto/update-user.dto.ts
+++ b/src/users/dto/update-user.dto.ts
@@ -70,4 +70,23 @@ export class UpdateUserDto {
   @IsOptional()
   @IsString()
   walletAddress?: string;
+
+  @ApiProperty({
+    description: 'Optional PIN for the user (6 digits)',
+    example: '654321',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  @MinLength(6)
+  pin?: string;
+
+  @ApiProperty({
+    description: 'Optional refresh token for the user',
+    example: 'some_refresh_token',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  refreshToken?: string;
 }


### PR DESCRIPTION
This commit introduces a comprehensive update to the authentication system, adding two major features: PIN-based login for inspectors and a secure refresh token mechanism with token rotation.

Key changes include:
1.  *Inspector PIN Login:*
     -   A new endpoint POST /auth/login/inspector is created for a streamlined login experience for inspectors.
     -   Inspectors can now log in using a unique 6-digit PIN instead of a password.
     -   The PIN is securely hashed using bcrypt upon creation and update, and compared safely during login.
     -   A new ManualPinStrategy and ManualPinAuthGuard have been implemented to handle this specific authentication flow.

2.  *Refresh Token Implementation:*
     -   The login process now generates both a short-lived accessToken and a long-lived refreshToken.
     -   The refreshToken is hashed and stored in the database for enhanced security.
     -   A new endpoint POST /auth/refresh allows clients to obtain a new accessToken without requiring the user to log in again.
     -   Implements *Refresh Token Rotation*: upon refreshing, a new refreshToken is issued and its hash is updated in the database, invalidating the previous one.

3.  *Endpoint Security:*
     -   The POST /inspections endpoint is now secured, requiring JWT authentication and the INSPECTOR role.
     -   The inspectorId from the authenticated user's token is now automatically associated with the newly created inspection record.

4.  *Database Schema:*
     -   The User model in schema.prisma has been updated to include pin and refreshToken fields to support these new features.