### PR TITLE
feat(inspections): implement robust magic number validation for uploads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "class-validator": "^0.14.1",
         "date-fns": "^3.6.0",
         "date-fns-tz": "^3.2.0",
+        "file-type": "^21.0.0",
         "helmet": "^8.1.0",
         "ipfs-http-client": "^56.0.3",
         "papaparse": "^5.5.3",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "class-validator": "^0.14.1",
     "date-fns": "^3.6.0",
     "date-fns-tz": "^3.2.0",
+    "file-type": "^21.0.0",
     "helmet": "^8.1.0",
     "ipfs-http-client": "^56.0.3",
     "papaparse": "^5.5.3",

--- a/src/inspections/pipes/file-validation.pipe.ts
+++ b/src/inspections/pipes/file-validation.pipe.ts
@@ -1,0 +1,105 @@
+import {
+  PipeTransform,
+  Injectable,
+  ArgumentMetadata,
+  BadRequestException,
+  InternalServerErrorException,
+  Logger,
+} from '@nestjs/common';
+import * as fs from 'fs/promises';
+import { extname } from 'path';
+
+const MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024; // 5 MB
+const ALLOWED_MIME_TYPES = /^image\/(jpg|jpeg|png)$/;
+const ALLOWED_EXTENSIONS = /\.(jpg|jpeg|png)$/i;
+
+@Injectable()
+export class FileValidationPipe implements PipeTransform {
+  private readonly logger = new Logger(FileValidationPipe.name);
+
+  async transform(
+    files: Express.Multer.File | Express.Multer.File[],
+    metadata: ArgumentMetadata,
+  ) {
+    if (!files) {
+      throw new BadRequestException('File upload is required.');
+    }
+
+    if (Array.isArray(files)) {
+      if (files.length === 0) {
+        throw new BadRequestException('At least one file must be uploaded.');
+      }
+      // Validate each file in the array
+      for (const file of files) {
+        await this.validateFile(file);
+      }
+    } else {
+      // Validate a single file
+      await this.validateFile(files);
+    }
+
+    return files;
+  }
+
+  private async validateFile(file: Express.Multer.File): Promise<void> {
+    // 1. Basic check from Multer
+    if (!file || !file.path) {
+      throw new BadRequestException('Invalid file uploaded.');
+    }
+
+    // 2. Size Validation
+    if (file.size > MAX_FILE_SIZE_BYTES) {
+      await this.cleanupFile(file.path);
+      throw new BadRequestException(
+        `File "${file.originalname}" exceeds the size limit of 5 MB.`,
+      );
+    }
+
+    // 3. Mimetype and Extension Validation
+    if (
+      !ALLOWED_MIME_TYPES.test(file.mimetype) ||
+      !ALLOWED_EXTENSIONS.test(extname(file.originalname))
+    ) {
+      await this.cleanupFile(file.path);
+      throw new BadRequestException(
+        `File "${file.originalname}" has an invalid type. Only JPG, JPEG, PNG, and GIF are allowed.`,
+      );
+    }
+
+    // 4. Magic Number Validation
+    try {
+      const { fileTypeFromBuffer } = await (eval(
+        'import("file-type")',
+      ) as Promise<typeof import('file-type')>);
+
+      const buffer = await fs.readFile(file.path);
+      const type = await fileTypeFromBuffer(buffer);
+
+      if (!type || !ALLOWED_MIME_TYPES.test(type.mime)) {
+        await this.cleanupFile(file.path);
+        throw new BadRequestException(
+          `File content of "${file.originalname}" does not match its extension.`,
+        );
+      }
+    } catch (error) {
+      await this.cleanupFile(file.path);
+      this.logger.error(`Validation failed for ${file.originalname}:`, error);
+      if (error instanceof BadRequestException) {
+        throw error;
+      }
+      throw new InternalServerErrorException('Could not validate file type.');
+    }
+  }
+
+  /**
+   * Deletes a file from the filesystem. Used for cleanup when validation fails.
+   * @param filePath The path of the file to delete.
+   */
+  private async cleanupFile(filePath: string): Promise<void> {
+    try {
+      await fs.unlink(filePath);
+    } catch (error) {
+      this.logger.error(`Failed to clean up file: ${filePath}`, error);
+    }
+  }
+}


### PR DESCRIPTION
Refactors the file upload mechanism to significantly improve security and reliability.

The previous implementation only validated the file's mimetype and extension, which can be easily spoofed. This commit introduces a more robust, multi-layered validation approach by leveraging a custom NestJS Pipe.

Key changes:
- A new  is created to handle all validation logic after the file has been saved to disk by Multer.
- The pipe now validates against:
  - File size (max 5MB)
  - Mimetype and extension
  - Magic number (file signature) using  to ensure the file content matches its type.
- If validation fails at any step, the temporarily saved file is automatically deleted, and a clear  is returned to the user.
- This new approach replaces the previous  in Multer options, which caused runtime errors due to race conditions with file streams.