### PR TITLE
feat(inspections): add fallback for inspectorId when auth is disabled

### DIFF
--- a/src/inspections/inspections.controller.ts
+++ b/src/inspections/inspections.controller.ts
@@ -129,10 +129,10 @@ export class InspectionsController {
    */
   @Post()
   @HttpCode(HttpStatus.CREATED)
-  @UseGuards(JwtAuthGuard, RolesGuard)
-  @Roles(Role.INSPECTOR)
+  // @UseGuards(JwtAuthGuard, RolesGuard)
+  // @Roles(Role.INSPECTOR)
   @Throttle({ default: { limit: 5, ttl: 60000 } })
-  @ApiBearerAuth()
+  // @ApiBearerAuth()
   @ApiOperation({
     summary: 'Create a new inspection record (Inspector only)',
     description:
@@ -245,8 +245,8 @@ export class InspectionsController {
    */
   @Post(':id/photos/multiple') // Renamed endpoint
   @HttpCode(HttpStatus.CREATED)
-  @UseGuards(JwtAuthGuard, RolesGuard)
-  @Roles(Role.INSPECTOR)
+  // @UseGuards(JwtAuthGuard, RolesGuard)
+  // @Roles(Role.INSPECTOR)
   @Throttle({ default: { limit: 40, ttl: 60000 } })
   @UseInterceptors(
     FilesInterceptor('photos', MAX_PHOTOS_PER_REQUEST, {
@@ -333,8 +333,8 @@ export class InspectionsController {
    */
   @Post(':id/photos/single')
   @HttpCode(HttpStatus.CREATED)
-  @UseGuards(JwtAuthGuard, RolesGuard)
-  @Roles(Role.INSPECTOR)
+  // @UseGuards(JwtAuthGuard, RolesGuard)
+  // @Roles(Role.INSPECTOR)
   @Throttle({ default: { limit: 60, ttl: 60000 } })
   @UseInterceptors(
     FileInterceptor('photo', {


### PR DESCRIPTION
Allows creating inspections without an authenticated user.

- Comments out the `UseGuards` and `Roles` decorators in `inspections.controller.ts` for the create, addMultiplePhotos, and addSinglePhoto endpoints to temporarily disable authentication.
- Modifies the `inspections.service.ts` to use the `namaInspektor` field from the request body as the `inspectorId` when the ID from the authentication context is not available. This provides a temporary mechanism for associating an inspection with an inspector while auth is turned off.