### PR TITLE
feat(inspections): Generate full and no-docs PDFs in parallel

### DIFF
--- a/prisma/migrations/20250726091724_add_no_docs_pdf_fields/migration.sql
+++ b/prisma/migrations/20250726091724_add_no_docs_pdf_fields/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "inspections" ADD COLUMN     "ipfs_pdf_no_docs" VARCHAR(255),
+ADD COLUMN     "pdf_file_hash_no_docs" VARCHAR(255),
+ADD COLUMN     "url_pdf_no_docs" VARCHAR(255);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -135,6 +135,10 @@ model Inspection {
   // Cryptographic hash (e.g., SHA-256) of the generated PDF file. Optional. Explicit mapping. Max length 255.
   pdfFileHash        String?        @map("pdf_file_hash") @db.VarChar(255)
 
+  urlPdfNoDocs       String?        @map("url_pdf_no_docs") @db.VarChar(255)
+  ipfsPdfNoDocs      String?        @map("ipfs_pdf_no_docs") @db.VarChar(255)
+  pdfFileHashNoDocs  String?        @map("pdf_file_hash_no_docs") @db.VarChar(255)
+
   // --- Timestamps ---
   // Automatically set when the record is created.
   createdAt DateTime @default(now())

--- a/src/inspections/inspections.service.ts
+++ b/src/inspections/inspections.service.ts
@@ -908,7 +908,9 @@ export class InspectionsService {
     meta: { total: number; page: number; pageSize: number; totalPages: number };
   }> {
     this.logger.log(
-      `Retrieving inspections for user role: ${userRole ?? 'N/A'}, status: ${Array.isArray(status) ? status.join(',') : (status ?? 'ALL (default)')}, page: ${page}, pageSize: ${pageSize}`,
+      `Retrieving inspections for user role: ${userRole ?? 'N/A'}, status: ${
+        Array.isArray(status) ? status.join(',') : (status ?? 'ALL (default)')
+      }, page: ${page}, pageSize: ${pageSize}`,
     );
 
     // Initialize whereClause
@@ -999,7 +1001,9 @@ export class InspectionsService {
       });
 
       this.logger.log(
-        `Retrieved ${inspections.length} inspections of ${total} total for role ${userRole ?? 'N/A'}.`,
+        `Retrieved ${
+          inspections.length
+        } inspections of ${total} total for role ${userRole ?? 'N/A'}.`,
       );
 
       const totalPages = Math.ceil(total / pageSize);
@@ -1018,7 +1022,9 @@ export class InspectionsService {
       const errorStack =
         error instanceof Error ? error.stack : 'No stack trace available';
       this.logger.error(
-        `Failed to retrieve inspections for role ${userRole ?? 'N/A'}: ${errorMessage}`,
+        `Failed to retrieve inspections for role ${
+          userRole ?? 'N/A'
+        }: ${errorMessage}`,
         errorStack,
       );
       throw new InternalServerErrorException(
@@ -1095,6 +1101,37 @@ export class InspectionsService {
   }
 
   /**
+   * Generates, saves, and hashes a PDF from a given URL.
+   * This is a helper function for `approveInspection`.
+   * @param url The URL to generate the PDF from.
+   * @param baseFileName The unique filename for the PDF.
+   * @param token The JWT token for authentication.
+   * @returns An object with the public URL, IPFS CID, and hash of the PDF.
+   */
+  private async _generateAndSavePdf(
+    url: string,
+    baseFileName: string,
+    token: string | null,
+  ): Promise<{ pdfPublicUrl: string; pdfCid: string; pdfHashString: string }> {
+    const pdfBuffer = await this.generatePdfFromUrl(url, token);
+    const pdfCid = await this.ipfsService.add(pdfBuffer);
+    const pdfFilePath = path.join(PDF_ARCHIVE_PATH, baseFileName);
+    await fs.writeFile(pdfFilePath, pdfBuffer);
+    this.logger.log(`PDF report saved to: ${pdfFilePath}`);
+
+    const hash = crypto.createHash('sha256');
+    hash.update(pdfBuffer);
+    const pdfHashString = hash.digest('hex');
+    this.logger.log(
+      `PDF hash calculated for ${baseFileName}: ${pdfHashString}`,
+    );
+
+    const pdfPublicUrl = `${PDF_PUBLIC_BASE_URL}/${baseFileName}`;
+
+    return { pdfPublicUrl, pdfCid, pdfHashString };
+  }
+
+  /**
    * Approves an inspection, applies the latest logged change for each field,
    * generates and stores the PDF, calculates its hash, and changes status to APPROVED.
    * Fetches the latest changes from InspectionChangeLog and updates the Inspection record.
@@ -1140,44 +1177,29 @@ export class InspectionsService {
       );
     }
 
-    const frontendReportUrl = `${this.config.getOrThrow<string>(
+    // --- PDF Generation (Parallel) ---
+    const timestamp = Date.now();
+    const basePrettyId = inspection.pretty_id;
+
+    // Define URLs and filenames
+    const fullPdfUrl = `${this.config.getOrThrow<string>(
       'CLIENT_BASE_URL_PDF',
     )}/data/${inspection.id}`;
-    let pdfBuffer: Buffer;
-    let pdfCid: string;
-    let pdfHashString: string | null = null;
-    const pdfFileName = `${inspection.pretty_id}-${Date.now()}.pdf`; // Nama file unik
-    const pdfFilePath = path.join(PDF_ARCHIVE_PATH, pdfFileName);
-    const pdfPublicUrl = `${PDF_PUBLIC_BASE_URL}/${pdfFileName}`; // URL publik
+    const noDocsPdfUrl = `${this.config.getOrThrow<string>(
+      'CLIENT_BASE_URL_PDF',
+    )}/pdf/${inspection.id}`;
+
+    const fullPdfFileName = `${basePrettyId}-${timestamp}.pdf`;
+    const noDocsPdfFileName = `${basePrettyId}-no-confidential-${timestamp}.pdf`;
 
     try {
-      // Generate PDF from URL, passing the token
-      pdfBuffer = await this.generatePdfFromUrl(frontendReportUrl, token);
-      pdfCid = await this.ipfsService.add(pdfBuffer);
-      // Save PDF to Disc
-      await fs.writeFile(pdfFilePath, pdfBuffer);
-      this.logger.log(`PDF report saved to: ${pdfFilePath}`);
+      // Run PDF generation in parallel
+      const [fullPdfResult, noDocsPdfResult] = await Promise.all([
+        this._generateAndSavePdf(fullPdfUrl, fullPdfFileName, token),
+        this._generateAndSavePdf(noDocsPdfUrl, noDocsPdfFileName, token),
+      ]);
 
-      // Calculate PDF Hash
-      const hash = crypto.createHash('sha256');
-      hash.update(pdfBuffer);
-      pdfHashString = hash.digest('hex');
-      this.logger.log(`PDF hash calculated: ${pdfHashString}`);
-    } catch (error: unknown) {
-      const errorMessage =
-        error instanceof Error ? error.message : 'An unknown error occurred';
-      const errorStack =
-        error instanceof Error ? error.stack : 'No stack trace available';
-      this.logger.error(
-        `Failed to generate or save PDF for inspection ${inspectionId}: ${errorMessage}`,
-        errorStack,
-      );
-      throw new InternalServerErrorException(
-        `Could not generate PDF report from URL: ${errorMessage}`,
-      );
-    }
-
-    try {
+      // --- Transactional Database Update ---
       return this.prisma.$transaction(async (tx) => {
         // 2. Fetch all change logs for this inspection
         const allChanges = await tx.inspectionChangeLog.findMany({
@@ -1212,9 +1234,14 @@ export class InspectionsService {
           reviewer: {
             connect: { id: reviewerId },
           },
-          urlPdf: pdfPublicUrl,
-          pdfFileHash: pdfHashString,
-          ipfsPdf: `ipfs://${pdfCid}`,
+          // Full PDF data
+          urlPdf: fullPdfResult.pdfPublicUrl,
+          pdfFileHash: fullPdfResult.pdfHashString,
+          ipfsPdf: `ipfs://${fullPdfResult.pdfCid}`,
+          // No-Docs PDF data
+          urlPdfNoDocs: noDocsPdfResult.pdfPublicUrl,
+          pdfFileHashNoDocs: noDocsPdfResult.pdfHashString,
+          ipfsPdfNoDocs: `ipfs://${noDocsPdfResult.pdfCid}`,
         };
 
         // Define which top-level fields in Inspection are JSON and can be updated via change log
@@ -1234,16 +1261,17 @@ export class InspectionsService {
           const fieldName = parts[0] as keyof Inspection; // Assert fieldName type
 
           this.logger.debug(
-            `Applying change: fieldKey=${fieldKey}, value=${JSON.stringify(value)}, fieldName=${fieldName}`,
+            `Applying change: fieldKey=${fieldKey}, value=${JSON.stringify(
+              value,
+            )}, fieldName=${fieldName}`,
           );
 
           if (parts.length === 1) {
             this.logger.debug(
-              `Processing top-level field from changelog. fieldName: "${fieldName}", value: "${JSON.stringify(value)}"`,
-            ); // KILOCODE DEBUG LOG
-            // Handle top-level fields (fieldName only)
-            // Only attempt to update if the field exists in the original inspection object
-            // KILOCODE FIX: Use parts[0] for 'inspector' and 'branchCity' checks to avoid TS error
+              `Processing top-level field from changelog. fieldName: "${fieldName}", value: "${JSON.stringify(
+                value,
+              )}"`,
+            );
             if (
               parts[0] === 'inspector' &&
               value !== null &&
@@ -1268,9 +1296,7 @@ export class InspectionsService {
               this.logger.debug(
                 `Applied branchCity change using connect: ${value}`,
               );
-            }
-            // KILOCODE FIX: Fallback to check actual properties on inspection object using fieldName (keyof Inspection)
-            else if (
+            } else if (
               Object.prototype.hasOwnProperty.call(inspection, fieldName)
             ) {
               // Handle specific top-level fields with proper type conversion
@@ -1297,7 +1323,18 @@ export class InspectionsService {
               }
             } else {
               this.logger.warn(
-                `Top-level field "${parts[0]}" from changelog (key: ${fieldKey}) did not match any specific update logic. Value: ${JSON.stringify(value)}. 'inspector' check: ${parts[0] === 'inspector'}. 'branchCity' check: ${parts[0] === 'branchCity'}. HasOwnProperty on inspection for fieldName: ${Object.prototype.hasOwnProperty.call(inspection, fieldName)}. Ignoring.`, // KILOCODE DEBUG LOG MODIFIED with parts[0]
+                `Top-level field "${
+                  parts[0]
+                }" from changelog (key: ${fieldKey}) did not match any specific update logic. Value: ${JSON.stringify(
+                  value,
+                )}. 'inspector' check: ${
+                  parts[0] === 'inspector'
+                }. 'branchCity' check: ${
+                  parts[0] === 'branchCity'
+                }. HasOwnProperty on inspection for fieldName: ${Object.prototype.hasOwnProperty.call(
+                  inspection,
+                  fieldName,
+                )}. Ignoring.`,
               );
             }
           } else {


### PR DESCRIPTION
This commit introduces the capability to generate two distinct PDF reports upon inspection approval: a complete version and a "no-docs" version which omits confidential information.

Key changes include:
- Updated the Prisma schema to include new fields in the  model for storing the URL, hash, and IPFS CID of the no-docs PDF.
- Added a new database migration to apply these schema changes.
- Refactored the  method in .
- Extracted PDF generation logic into a private helper method  to improve code reuse and clarity.
- Implemented parallel PDF generation using  to significantly improve the performance and efficiency of the approval process.