### PR TITLE
feat(minting): Update NFT metadata for inspection minting

### DIFF
--- a/prisma/migrations/20250726091724_add_no_docs_pdf_fields/migration.sql
+++ b/prisma/migrations/20250726091724_add_no_docs_pdf_fields/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "inspections" ADD COLUMN     "ipfs_pdf_no_docs" VARCHAR(255),
+ADD COLUMN     "pdf_file_hash_no_docs" VARCHAR(255),
+ADD COLUMN     "url_pdf_no_docs" VARCHAR(255);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -135,6 +135,10 @@ model Inspection {
   // Cryptographic hash (e.g., SHA-256) of the generated PDF file. Optional. Explicit mapping. Max length 255.
   pdfFileHash        String?        @map("pdf_file_hash") @db.VarChar(255)
 
+  urlPdfNoDocs       String?        @map("url_pdf_no_docs") @db.VarChar(255)
+  ipfsPdfNoDocs      String?        @map("ipfs_pdf_no_docs") @db.VarChar(255)
+  pdfFileHashNoDocs  String?        @map("pdf_file_hash_no_docs") @db.VarChar(255)
+
   // --- Timestamps ---
   // Automatically set when the record is created.
   createdAt DateTime @default(now())

--- a/src/blockchain/blockchain.service.ts
+++ b/src/blockchain/blockchain.service.ts
@@ -53,8 +53,8 @@ import { PlutusBlueprint, PlutusValidator } from './types/blueprint.type';
  */
 export interface InspectionNftMetadata {
   vehicleNumber: string;
-  pdfUrl: string;
   pdfHash: string;
+  pdfHashNonConfidential: string;
 }
 interface Script {
   code: string;
@@ -469,6 +469,7 @@ export class BlockchainService {
               description: 'NFT Proof of Vehicle Inspection',
               vehicleNumber: inspectionData.vehicleNumber,
               hash_pdf: inspectionData.pdfHash,
+              hash_pdf_non_confidential: inspectionData.pdfHashNonConfidential,
             },
           },
         },

--- a/src/blockchain/dto/build-mint-tx.dto.ts
+++ b/src/blockchain/dto/build-mint-tx.dto.ts
@@ -47,6 +47,18 @@ class InspectionDataDto {
   pdfHash: string;
 
   /**
+   * The SHA-256 hash of the PDF file content without confidential data.
+   */
+  @ApiProperty({
+    description:
+      'The SHA-256 hash of the PDF file content without confidential data.',
+    example: 'd4e5f6...',
+  })
+  @IsString()
+  @IsNotEmpty()
+  pdfHashNonConfidential: string;
+
+  /**
    * The display name for the NFT.
    */
   @ApiProperty({


### PR DESCRIPTION
This commit updates the NFT minting process to align with new metadata requirements.

- The field is now included in the NFT metadata for both simple and smart contract-based minting.
- The and IPFS-related fields are removed from the metadata created by the function, as they are no longer required on the NFT.
- The function (simple mint) retains its existing metadata structure, including the static IPFS image, as requested.
- DTOs and service logic have been updated to support these changes and ensure correct data mapping from the database to the blockchain.