### PR TITLE
feat: upgrade pdf hash algorithm to sha512

### DIFF
--- a/src/blockchain/dto/transaction-metadata-response.dto.ts
+++ b/src/blockchain/dto/transaction-metadata-response.dto.ts
@@ -50,7 +50,7 @@ export class TransactionMetadataResponseDto {
           mediaType: 'image/png',
           description: 'NFT Proof of Vehicle Inspection',
           vehicleNumber: 'XYZ123', // Example vehicle number
-          pdfHash: 'sha256...', // Example PDF hash
+          pdfHash: 'sha512...', // Example PDF hash
         },
       },
     },

--- a/src/inspections/inspections.service.ts
+++ b/src/inspections/inspections.service.ts
@@ -1120,7 +1120,7 @@ export class InspectionsService {
     await fs.writeFile(pdfFilePath, pdfBuffer);
     this.logger.log(`PDF report saved to: ${pdfFilePath}`);
 
-    const hash = crypto.createHash('sha256');
+    const hash = crypto.createHash('sha512');
     hash.update(pdfBuffer);
     const pdfHashString = hash.digest('hex');
     this.logger.log(

--- a/src/scalar-docs/openapi-spec.ts
+++ b/src/scalar-docs/openapi-spec.ts
@@ -2318,7 +2318,7 @@ export const openApiDocument = {
                   vehicleModel: 'Camry',
                   overallRating: 'Excellent',
                   pdfUrl: 'https://example.com/report.pdf',
-                  pdfHash: 'sha256...',
+                  pdfHash: 'sha512...',
                   inspectorId: 'inspector-uuid...',
                 },
               },


### PR DESCRIPTION
Upgraded the PDF hashing algorithm from SHA256 to SHA512 for improved security. This change affects the inspection service where the PDF hash is calculated. Documentation and DTOs have been updated to reflect the new algorithm.