### PR TITLE
fix: replace root-based imports with relative paths

### DIFF
--- a/src/inspections/inspections.controller.ts
+++ b/src/inspections/inspections.controller.ts
@@ -56,8 +56,9 @@ import {
   ApiTags,
   ApiBearerAuth,
 } from '@nestjs/swagger';
-import { AddMultiplePhotosDto } from 'src/photos/dto/add-multiple-photos.dto';
-import { AddSinglePhotoDto } from 'src/inspections/dto/add-single-photo.dto';
+// Use relative imports to avoid module resolution issues in tests and runtime
+import { AddMultiplePhotosDto } from '../photos/dto/add-multiple-photos.dto';
+import { AddSinglePhotoDto } from './dto/add-single-photo.dto';
 import { BuildMintTxResponseDto } from '../blockchain/dto/build-mint-tx-response.dto';
 import { BuildMintRequestDto } from './dto/build-mint-request.dto';
 import { ConfirmMintDto } from './dto/confirm-mint.dto';

--- a/src/public-api/public-api.controller.ts
+++ b/src/public-api/public-api.controller.ts
@@ -29,14 +29,15 @@ import { ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 // Services
 import { UsersService } from '../users/users.service';
-import { InspectionsService } from 'src/inspections/inspections.service';
+// Use relative imports instead of root-based paths for better Jest compatibility
+import { InspectionsService } from '../inspections/inspections.service';
 import { PublicApiService } from './public-api.service';
 
 // DTOs (Data Transfer Objects)
 import { UserResponseDto } from '../users/dto/user-response.dto';
-import { LatestArchivedInspectionResponseDto } from 'src/inspections/dto/latest-archived-inspection-response.dto';
-import { InspectionResponseDto } from 'src/inspections/dto/inspection-response.dto';
-import { InspectionChangeLogResponseDto } from 'src/inspection-change-log/dto/inspection-change-log-response.dto';
+import { LatestArchivedInspectionResponseDto } from '../inspections/dto/latest-archived-inspection-response.dto';
+import { InspectionResponseDto } from '../inspections/dto/inspection-response.dto';
+import { InspectionChangeLogResponseDto } from '../inspection-change-log/dto/inspection-change-log-response.dto';
 
 // Prisma types
 import { InspectionChangeLog } from '@prisma/client';


### PR DESCRIPTION
## Summary
- use relative imports in inspections controller to avoid module resolution issues
- use relative imports in public API controller for consistent resolution

## Testing
- `npm test` *(fails: TS2740, Nest dependency resolution errors)*

------
https://chatgpt.com/codex/tasks/task_e_68980744727c832bbfe76f31e851901f