### PR TITLE
feat: add feature to toggle inspection branch status

### DIFF
--- a/prisma/migrations/20250811130325_add_is_active_to_branch_city/migration.sql
+++ b/prisma/migrations/20250811130325_add_is_active_to_branch_city/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "inspection_branch_city" ADD COLUMN     "is_active" BOOLEAN NOT NULL DEFAULT true;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -191,6 +191,7 @@ model InspectionBranchCity {
   id        String   @id @default(uuid())
   city      String   @unique
   code      String   @unique @db.VarChar(3)
+  isActive  Boolean  @default(true) @map("is_active")
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 

--- a/src/inspection-branches/dto/create-inspection-branch-city.dto.ts
+++ b/src/inspection-branches/dto/create-inspection-branch-city.dto.ts
@@ -10,7 +10,7 @@
  * --------------------------------------------------------------------------
  */
 
-import { IsString, IsNotEmpty, MaxLength } from 'class-validator';
+import { IsString, IsNotEmpty, MaxLength, IsBoolean, IsOptional } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 /**
@@ -26,4 +26,17 @@ export class CreateInspectionBranchCityDto {
   @IsNotEmpty()
   @MaxLength(255)
   city: string;
+
+  /**
+   * The status of the inspection branch city.
+   * @example true
+   */
+  @ApiProperty({
+    example: true,
+    description: 'Status of the city',
+    required: false,
+  })
+  @IsBoolean()
+  @IsOptional()
+  isActive?: boolean;
 }

--- a/src/inspection-branches/dto/inspection-branch-city-response.dto.ts
+++ b/src/inspection-branches/dto/inspection-branch-city-response.dto.ts
@@ -34,6 +34,13 @@ export class InspectionBranchCityResponseDto {
   city: string;
 
   /**
+   * The status of the inspection branch city.
+   * @example true
+   */
+  @ApiProperty({ example: true, description: 'Status of the city' })
+  isActive: boolean;
+
+  /**
    * The code or name of the inspection branch.
    * @example 'Main Branch'
    */

--- a/src/inspection-branches/inspection-branches.controller.ts
+++ b/src/inspection-branches/inspection-branches.controller.ts
@@ -21,6 +21,7 @@ import {
   Delete,
   UseGuards,
   HttpStatus,
+  Patch,
 } from '@nestjs/common';
 import {
   ApiTags,
@@ -232,5 +233,51 @@ export class InspectionBranchesController {
   })
   async remove(@Param('id') id: string) {
     return await this.inspectionBranchesService.remove(id);
+  }
+
+  /**
+   * Toggles the active status of an inspection branch city by its ID.
+   * Restricted to ADMIN and SUPERADMIN roles only.
+   *
+   * @param id The ID of the inspection branch city to toggle.
+   * @returns A promise that resolves to the updated InspectionBranchCityResponseDto.
+   * @throws UnauthorizedException if the user is not authenticated.
+   * @throws ForbiddenException if the user does not have the required role.
+   * @throws NotFoundException if the inspection branch city is not found.
+   */
+  @Patch(':id/toggle-active')
+  @Throttle({ default: { limit: 4, ttl: 60000 } })
+  @UseGuards(ThrottlerGuard)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Role.ADMIN, Role.SUPERADMIN)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Toggle the active status of an inspection branch city by ID',
+  })
+  @ApiParam({
+    name: 'id',
+    type: String,
+    description: 'Inspection branch city ID',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description:
+      'The inspection branch city has been successfully status updated.',
+    type: InspectionBranchCityResponseDto,
+  })
+  @ApiResponse({
+    status: HttpStatus.UNAUTHORIZED,
+    description: 'User is not authenticated.',
+  })
+  @ApiResponse({
+    status: HttpStatus.FORBIDDEN,
+    description: 'User does not have the required permissions.',
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'Inspection branch city not found.',
+  })
+  async toggleActive(@Param('id') id: string) {
+    return await this.inspectionBranchesService.toggleActive(id);
   }
 }

--- a/src/inspection-branches/inspection-branches.service.ts
+++ b/src/inspection-branches/inspection-branches.service.ts
@@ -36,6 +36,7 @@ export class InspectionBranchesService {
       data: {
         city: createInspectionBranchCityDto.city,
         code: code,
+        isActive: createInspectionBranchCityDto.isActive,
       },
     });
   }
@@ -87,6 +88,7 @@ export class InspectionBranchesService {
       where: { id },
       data: {
         city: updateInspectionBranchCityDto.city,
+        isActive: updateInspectionBranchCityDto.isActive,
       },
     });
   }
@@ -102,6 +104,21 @@ export class InspectionBranchesService {
     await this.findOne(id); // Check if exists before deleting
     return await this.prisma.inspectionBranchCity.delete({
       where: { id },
+    });
+  }
+
+  /**
+   * Toggles the active status of an inspection branch city.
+   *
+   * @param id The ID of the inspection branch city to toggle.
+   * @returns A promise that resolves to the updated InspectionBranchCity.
+   * @throws NotFoundException if the inspection branch city with the given ID is not found.
+   */
+  async toggleActive(id: string): Promise<InspectionBranchCity> {
+    const branch = await this.findOne(id);
+    return this.prisma.inspectionBranchCity.update({
+      where: { id },
+      data: { isActive: !branch.isActive },
     });
   }
 }


### PR DESCRIPTION
This commit introduces a new feature to activate or deactivate inspection branch cities.

- Adds `isActive` boolean field to the `InspectionBranchCity` model in `schema.prisma`.
- Creates a database migration to apply this schema change.
- Updates `CreateInspectionBranchCityDto` and `InspectionBranchCityResponseDto` to include the `isActive` status.
- Implements the `toggleActive` method in `InspectionBranchesService` to switch the status.
- Adds a new PATCH endpoint `/inspection-branches/:id/toggle-active` in `InspectionBranchesController` to expose this functionality, restricted to ADMIN and SUPERADMIN roles.