### PR TITLE
feat(dto): Resolve duplicate DTO name conflicts

### DIFF
--- a/src/inspections/dto/inspection-response.dto.ts
+++ b/src/inspections/dto/inspection-response.dto.ts
@@ -19,7 +19,7 @@ import { ApiProperty } from '@nestjs/swagger';
 /**
  * Data Transfer Object (DTO) representing a photo associated with an inspection.
  */
-export class PhotoResponseDto {
+export class PhotoDetailResponseDTO {
   @ApiProperty({
     example: 'add815ce-d602-4e49-a360-e6012e23cead',
     description: 'The unique identifier (UUID) for the photo record.',
@@ -92,7 +92,7 @@ export class PhotoResponseDto {
   })
   updatedAt: Date;
 
-  constructor(partial: Partial<PhotoResponseDto>) {
+  constructor(partial: Partial<PhotoDetailResponseDTO>) {
     Object.assign(this, partial);
   }
 }
@@ -489,10 +489,10 @@ export class InspectionResponseDto {
     ],
     description:
       'An array containing metadata for photos associated with this inspection.',
-    type: PhotoResponseDto, // Specify the DTO type for array items
+    type: PhotoDetailResponseDTO, // Specify the DTO type for array items
     isArray: true, // Indicate that this is an array
   })
-  photos: PhotoResponseDto[]; // Use the new PhotoResponseDto type
+  photos: PhotoDetailResponseDTO[]; // Use the new PhotoDetailResponseDTO type
 
   /**
    * The URL pointing to the generated PDF report file (stored off-chain).
@@ -634,17 +634,21 @@ export class InspectionResponseDto {
    * Constructor to facilitate mapping from a Prisma Inspection entity.
    * Uses Object.assign for straightforward mapping of properties with the same name.
    * Can be extended to explicitly map or exclude fields if needed.
-   * @param {Partial<Inspection & { photos: Partial<PhotoResponseDto>[] }>} partial - The Prisma Inspection entity or a partial object including photos.
+   * @param {Partial<Inspection & { photos: Partial<PhotoDetailResponseDTO>[] }>} partial - The Prisma Inspection entity or a partial object including photos.
    */
   constructor(
-    partial: Partial<Inspection & { photos: Partial<PhotoResponseDto>[] }>,
+    partial: Partial<
+      Inspection & { photos: Partial<PhotoDetailResponseDTO>[] }
+    >,
   ) {
     // Copies properties from the Prisma entity to this DTO instance
     Object.assign(this, partial);
 
-    // Map the photos array to PhotoResponseDto instances
+    // Map the photos array to PhotoDetailResponseDTO instances
     if (partial.photos && Array.isArray(partial.photos)) {
-      this.photos = partial.photos.map((photo) => new PhotoResponseDto(photo));
+      this.photos = partial.photos.map(
+        (photo) => new PhotoDetailResponseDTO(photo),
+      );
     } else {
       this.photos = [];
     }

--- a/src/users/dto/inspection-branch-city-response.dto.ts
+++ b/src/users/dto/inspection-branch-city-response.dto.ts
@@ -14,7 +14,7 @@ import { InspectionBranchCity } from '@prisma/client';
 /**
  * DTO for public-facing inspection branch city data.
  */
-export class InspectionBranchCityResponseDto {
+export class UserInspectionBranchCityResponseDto {
   @ApiProperty({ description: 'Branch city unique identifier (UUID)' })
   id: string;
 

--- a/src/users/dto/user-response.dto.ts
+++ b/src/users/dto/user-response.dto.ts
@@ -12,7 +12,7 @@
 
 import { ApiProperty } from '@nestjs/swagger';
 import { InspectionBranchCity, Role, User } from '@prisma/client';
-import { InspectionBranchCityResponseDto } from './inspection-branch-city-response.dto';
+import { UserInspectionBranchCityResponseDto } from './inspection-branch-city-response.dto';
 
 /**
  * DTO representing the public-facing user data.
@@ -91,9 +91,9 @@ export class UserResponseDto {
   @ApiProperty({
     description: 'The inspection branch city the user is associated with',
     nullable: true,
-    type: () => InspectionBranchCityResponseDto,
+    type: () => UserInspectionBranchCityResponseDto,
   })
-  inspectionBranchCity: InspectionBranchCityResponseDto | null;
+  inspectionBranchCity: UserInspectionBranchCityResponseDto | null;
 
   /**
    * Constructor to map from a Prisma User entity to this DTO.
@@ -114,7 +114,7 @@ export class UserResponseDto {
     this.createdAt = user.createdAt;
     this.updatedAt = user.updatedAt;
     this.inspectionBranchCity = user.inspectionBranchCity
-      ? new InspectionBranchCityResponseDto(user.inspectionBranchCity)
+      ? new UserInspectionBranchCityResponseDto(user.inspectionBranchCity)
       : null;
     // Explicitly excluded: password, googleId
   }


### PR DESCRIPTION
Resolves "Duplicate DTO detected" errors on startup by renaming conflicting Data Transfer Objects.

- Renamed `PhotoResponseDto` within the inspections module to `PhotoDetailResponseDTO` to distinguish it from the primary DTO in the photos module.
- Renamed `InspectionBranchCityResponseDto` within the users module to `UserInspectionBranchCityResponseDto` to avoid conflicts with the DTO in the inspection-branches module.

These changes ensure that all DTO class names are unique across the application, which is a requirement for the OpenAPI specification generation and avoids runtime errors in NestJS.