### PR TITLE
feat: Implement dynamic branch logic and secure photo endpoints

### DIFF
--- a/src/inspections/inspections.controller.ts
+++ b/src/inspections/inspections.controller.ts
@@ -249,15 +249,13 @@ export class InspectionsController {
   @Post(':id/photos/multiple') // Renamed endpoint
   @SkipThrottle()
   @HttpCode(HttpStatus.CREATED)
-  // @UseGuards(JwtAuthGuard, RolesGuard)
-  // @Roles(Role.INSPECTOR)
   @UseInterceptors(
     FilesInterceptor('photos', MAX_PHOTOS_PER_REQUEST, {
       storage: photoStorageConfig,
     }),
   )
-  // @UseGuards(JwtAuthGuard, RolesGuard)
-  // @Roles(Role.ADMIN, Role.REVIEWER, Role.INSPECTOR)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Role.ADMIN, Role.REVIEWER, Role.INSPECTOR)
   @ApiOperation({
     summary: 'Upload a batch of photos for an inspection', // Updated summary
     description:
@@ -337,8 +335,8 @@ export class InspectionsController {
   @Post(':id/photos/single')
   @SkipThrottle()
   @HttpCode(HttpStatus.CREATED)
-  // @UseGuards(JwtAuthGuard, RolesGuard)
-  // @Roles(Role.INSPECTOR)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Role.ADMIN, Role.REVIEWER, Role.INSPECTOR)
   @UseInterceptors(
     FileInterceptor('photo', {
       storage: photoStorageConfig,


### PR DESCRIPTION
In `inspections.service.ts`, the inspection creation logic is updated to prioritize the inspector's pre-assigned branch city. If the inspector does not have a branch city set in their profile, the system falls back to using the branch city provided in the request payload. This enhances data consistency by defaulting to the inspector's primary branch.

In `inspections.controller.ts`, the JWT authentication guards on the single and multiple photo upload endpoints have been re-enabled to ensure that only authenticated and authorized users can upload inspection photos.