### PR TITLE
fix(inspection-changelog): add DELETE endpoint for changelog entries

### DIFF
--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -49,7 +49,8 @@ import { JwtRefreshGuard } from './guards/jwt-refresh.guard';
       useFactory: async (configService: ConfigService) => ({
         secret: configService.get<string>('JWT_SECRET'),
         signOptions: {
-          expiresIn: configService.get<string>('JWT_EXPIRATION_TIME'),
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          expiresIn: configService.get<string>('JWT_EXPIRATION_TIME') as any,
         },
       }),
     }),

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -232,14 +232,16 @@ export class AuthService {
 
     try {
       const secret = this.configService.getOrThrow<string>('JWT_SECRET');
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const expiresIn = this.configService.getOrThrow<string>(
         'JWT_EXPIRATION_TIME',
-      );
+      ) as any;
       const refreshTokenSecret =
         this.configService.getOrThrow<string>('JWT_REFRESH_SECRET');
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const refreshTokenExpiresIn = this.configService.getOrThrow<string>(
         'JWT_REFRESH_EXPIRATION_TIME',
-      );
+      ) as any;
 
       const accessToken = this.jwtService.sign(payload, { secret, expiresIn });
       const refreshToken = this.jwtService.sign(payload, {

--- a/src/inspection-change-log/inspection-change-log.controller.ts
+++ b/src/inspection-change-log/inspection-change-log.controller.ts
@@ -10,7 +10,7 @@
  * --------------------------------------------------------------------------
  */
 
-import { Controller, Get, Param, UseGuards, HttpStatus } from '@nestjs/common';
+import { Controller, Get, Delete, Param, UseGuards, HttpStatus, HttpCode } from '@nestjs/common';
 import { InspectionChangeLogService } from './inspection-change-log.service';
 import { InspectionChangeLog, Role } from '@prisma/client';
 import {
@@ -78,5 +78,58 @@ export class InspectionChangeLogController {
     @Param('inspectionId') inspectionId: string,
   ): Promise<InspectionChangeLog[]> {
     return this.inspectionChangeLogService.findByInspectionId(inspectionId);
+  }
+
+  /**
+   * Deletes a change log for a specific inspection.
+   * Restricted to ADMIN, REVIEWER, and SUPERADMIN roles.
+   *
+   * @param inspectionId The ID of the inspection.
+   * @param changeLogId The ID of the change log.
+   * @returns A promise that resolves when the change log is successfully deleted.
+   * @throws UnauthorizedException if the user is not authenticated.
+   * @throws ForbiddenException if the user does not have the required role.
+   * @throws NotFoundException if the change log or inspection is not found.
+   */
+  @Delete(':changeLogId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Role.ADMIN, Role.REVIEWER, Role.SUPERADMIN)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Delete an inspection change log',
+    description: 'Deletes a specific change log entry for an inspection.',
+  })
+  @ApiParam({
+    name: 'inspectionId',
+    type: String,
+    description: 'The ID of the inspection',
+  })
+  @ApiParam({
+    name: 'changeLogId',
+    type: String,
+    description: 'The ID of the change log entry to delete',
+  })
+  @ApiResponse({
+    status: HttpStatus.NO_CONTENT,
+    description: 'Successfully deleted the inspection change log.',
+  })
+  @ApiResponse({
+    status: HttpStatus.UNAUTHORIZED,
+    description: 'User is not authenticated.',
+  })
+  @ApiResponse({
+    status: HttpStatus.FORBIDDEN,
+    description: 'User does not have the required permissions.',
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'Change log entry not found.',
+  })
+  async remove(
+    @Param('inspectionId') inspectionId: string,
+    @Param('changeLogId') changeLogId: string,
+  ): Promise<void> {
+    await this.inspectionChangeLogService.remove(inspectionId, changeLogId);
   }
 }

--- a/src/inspection-change-log/inspection-change-log.service.ts
+++ b/src/inspection-change-log/inspection-change-log.service.ts
@@ -53,4 +53,34 @@ export class InspectionChangeLogService {
 
     return Array.from(latestChangeLogsMap.values());
   }
+
+  /**
+   * Deletes a specific change log entry.
+   *
+   * @param inspectionId The ID of the inspection.
+   * @param changeLogId The ID of the change log to delete.
+   * @returns A promise that resolves to the deleted InspectionChangeLog object.
+   * @throws NotFoundException if the change log entry does not exist.
+   */
+  async remove(
+    inspectionId: string,
+    changeLogId: string,
+  ): Promise<InspectionChangeLog> {
+    const changeLog = await this.prisma.inspectionChangeLog.findFirst({
+      where: {
+        id: changeLogId,
+        inspectionId: inspectionId,
+      },
+    });
+
+    if (!changeLog) {
+      throw new NotFoundException(
+        `Change log with ID "${changeLogId}" not found for inspection "${inspectionId}".`,
+      );
+    }
+
+    return this.prisma.inspectionChangeLog.delete({
+      where: { id: changeLogId },
+    });
+  }
 }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -25,7 +25,7 @@ import { PrismaService } from '../prisma/prisma.service'; // Adjust path if need
 import { User, Role, Prisma } from '@prisma/client';
 import { RegisterUserDto } from '../auth/dto/register-user.dto'; // Import DTO for local registration
 import * as bcrypt from 'bcrypt'; // Import bcrypt for hashing
-import { v4 as uuidv4 } from 'uuid'; // Import uuid for generating unique IDs
+import { randomUUID } from 'crypto'; // Use Node.js built-in instead of uuid (uuid v9+ is ESM-only)
 import { CreateInspectorDto } from './dto/create-inspector.dto'; // Import CreateInspectorDto
 import { UpdateInspectorDto } from './dto/update-inspector.dto';
 import { UpdateUserDto } from './dto/update-user.dto'; // Import UpdateUserDto
@@ -285,7 +285,7 @@ export class UsersService {
     try {
       const newUser = await this.prisma.user.create({
         data: {
-          id: uuidv4(), // Generate a UUID for the new user
+          id: randomUUID(), // Generate a UUID for the new user
           email: normalizedEmail, // Store normalized email
           username: registerDto.username,
           password: hashedPassword, // Store the HASHED password
@@ -383,7 +383,7 @@ export class UsersService {
           // name: name ? name : undefined, // Example: only update if Google provides a name
         },
         create: {
-          id: uuidv4(), // Generate a UUID for the new user
+          id: randomUUID(), // Generate a UUID for the new user
           email: normalizedEmail,
           googleId: googleId,
           name: name || `User_${googleId.substring(0, 6)}`, // Provide a default name if missing
@@ -785,7 +785,7 @@ export class UsersService {
     try {
       const newUser = await this.prisma.user.create({
         data: {
-          id: uuidv4(), // Generate a UUID for the new user
+          id: randomUUID(), // Generate a UUID for the new user
           email: createInspectorDto.email.toLowerCase(), // Store email in lowercase
           username: createInspectorDto.username,
           name: createInspectorDto.name,
@@ -1261,7 +1261,7 @@ export class UsersService {
     try {
       const newUser = await this.prisma.user.create({
         data: {
-          id: uuidv4(),
+          id: randomUUID(),
           email: createAdminDto.email.toLowerCase(),
           username: createAdminDto.username,
           password: hashedPassword,


### PR DESCRIPTION
- Add DELETE /inspections/:inspectionId/changelog/:changeLogId endpoint
- Implement remove() method in InspectionChangeLogService
- Fix TypeScript type error: cast expiresIn to any in auth.module.ts and auth.service.ts
- Replace uuid package (ESM-only) with Node.js built-in crypto.randomUUID()

Closes #114