### PR TITLE
feat(observability): deliver Sprint 1 telemetry baseline

### DIFF
--- a/docs/observability/telemetry-contract.md
+++ b/docs/observability/telemetry-contract.md
@@ -1,0 +1,100 @@
+# Telemetry Contract v1
+
+This document defines the observability contract for `cardano-backend` as a telemetry producer.
+
+## Scope
+
+- Applies to metrics emitted from `cardano-backend`.
+- Applies to request-level logging and error response metadata.
+- Defines trace/log/metric correlation primitives for Sprint 1 baseline.
+
+## Environment and service identity
+
+- `service`: `OBS_SERVICE_NAME` (default: `cardano-backend`)
+- `env`: `OBS_ENV` (fallback: `NODE_ENV`, default: `development`)
+
+## Metrics contract
+
+### Required RED metrics
+
+- `http_requests_total{service,env,method,route,status_class}`
+- `http_request_duration_seconds_bucket{service,env,method,route}`
+- `http_request_errors_total{service,env,method,route,error_type}`
+
+### Additional application metrics (existing)
+
+- `active_connections`
+- `database_connections_active`
+- `wallet_operations_total`
+- `ada_transfer_volume_lovelace`
+- `blockchain_sync_percentage`
+- `application_errors_total{service,env,error_type,route}`
+
+### Label policy
+
+Allowed labels:
+
+- `service`
+- `env`
+- `method`
+- `route`
+- `status_class`
+- `error_type`
+- `operation_type`
+- `status`
+
+Forbidden labels:
+
+- `userId`, `email`, `walletAddress`, `txHash`, `requestId`
+- raw query values
+- UUID/hash identifiers as metric labels
+
+### Route normalization rules
+
+Route labels must use templates instead of raw identifiers.
+
+Examples:
+
+- `/api/v1/inspections/123` -> `/api/v1/inspections/:id`
+- `/api/v1/inspections/7d9d2b1e-11e4-4b0f-9f8e-bf216fb0d8ad` -> `/api/v1/inspections/:uuid`
+- `/api/v1/blockchain/9f0caa1b...` -> `/api/v1/blockchain/:hash`
+
+### Error type conventions
+
+- `client_error` for HTTP `4xx`
+- `server_error` for HTTP `5xx`
+- application error names for `application_errors_total` (for example `ValidationError`, `AuthError`)
+
+## Request correlation contract
+
+- Incoming header supported: `x-request-id`
+- If missing/empty, server generates a UUID
+- Response echoes request ID in: `X-Request-ID`
+- Request ID is propagated in async request context and included by `AppLoggerService`
+- Error responses include `requestId` field when available
+
+## Logging baseline
+
+Sprint 1 baseline guarantees:
+
+- request ID propagation support in middleware and app logger
+- consistent inclusion of `requestId` in standardized error responses
+
+Sprint 2 extends to full structured JSON logging with `traceId` and `spanId` correlation.
+
+## Metrics endpoint
+
+- Endpoint: `GET /api/v1/metrics`
+- Content type: `text/plain`
+- Intended scraper: Prometheus
+- Recommended scrape config:
+  - interval: `15s`
+  - timeout: `5s`
+- Access control: enforce at reverse proxy/network layer (internal allowlist/basic auth)
+
+## Validation checklist
+
+- No forbidden labels used in RED metrics
+- Route labels are normalized templates
+- Error counter increments for `4xx` and `5xx`
+- Response includes `X-Request-ID`

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -37,6 +37,7 @@ import { MetricsModule } from './metrics/metrics.module';
 import { MetricsMiddleware } from './metrics/metrics.middleware';
 import { RedisModule } from './redis/redis.module';
 import { SecurityLoggerModule } from './security-logger/security-logger.module';
+import { RequestIdMiddleware } from './common/request-id.middleware';
 
 @Module({
   imports: [
@@ -122,6 +123,6 @@ import { SecurityLoggerModule } from './security-logger/security-logger.module';
 })
 export class AppModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {
-    consumer.apply(MetricsMiddleware).forRoutes('*');
+    consumer.apply(RequestIdMiddleware, MetricsMiddleware).forRoutes('*');
   }
 }

--- a/src/common/filters/all-exceptions.filter.spec.ts
+++ b/src/common/filters/all-exceptions.filter.spec.ts
@@ -24,7 +24,7 @@ describe('AllExceptionsFilter', () => {
     status: jest.Mock;
     json: jest.Mock;
   };
-  let mockRequest: { url: string };
+  let mockRequest: { url: string; headers: Record<string, string> };
   let mockHost: ArgumentsHost;
 
   beforeEach(() => {
@@ -35,7 +35,7 @@ describe('AllExceptionsFilter', () => {
       json: jest.fn().mockReturnThis(),
     };
 
-    mockRequest = { url: '/api/v1/test' };
+    mockRequest = { url: '/api/v1/test', headers: { 'x-request-id': 'req-1' } };
 
     mockHost = {
       switchToHttp: jest.fn().mockReturnValue({
@@ -63,6 +63,7 @@ describe('AllExceptionsFilter', () => {
     expect(body).toHaveProperty('errorCode');
     expect(body).toHaveProperty('path');
     expect(body).toHaveProperty('timestamp');
+    expect(body).toHaveProperty('requestId');
 
     expect(typeof body.statusCode).toBe('number');
     expect(Array.isArray(body.message)).toBe(true);
@@ -70,12 +71,14 @@ describe('AllExceptionsFilter', () => {
     expect(typeof body.errorCode).toBe('string');
     expect(typeof body.path).toBe('string');
     expect(typeof body.timestamp).toBe('string');
+    expect(typeof body.requestId).toBe('string');
 
     // Timestamp should be a valid ISO string
     expect(new Date(body.timestamp).toISOString()).toBe(body.timestamp);
 
     // Path should match request URL
     expect(body.path).toBe('/api/v1/test');
+    expect(body.requestId).toBe('req-1');
   }
 
   // ═══════════════════════════════════════════════════════════════
@@ -448,6 +451,15 @@ describe('AllExceptionsFilter', () => {
 
       expect(body.timestamp >= before).toBe(true);
       expect(body.timestamp <= after).toBe(true);
+    });
+
+    it('should omit requestId when request header is missing', () => {
+      mockRequest.headers = {};
+
+      filter.catch(new Error('test'), mockHost);
+
+      const body = getResponseBody();
+      expect(body.requestId).toBeUndefined();
     });
   });
 });

--- a/src/common/filters/all-exceptions.filter.ts
+++ b/src/common/filters/all-exceptions.filter.ts
@@ -37,6 +37,7 @@ export interface StandardErrorResponse {
   errorCode: string;
   path: string;
   timestamp: string;
+  requestId?: string;
 }
 
 @Catch()
@@ -65,6 +66,13 @@ export class AllExceptionsFilter implements ExceptionFilter {
   ): StandardErrorResponse {
     const timestamp = new Date().toISOString();
     const path = request.url;
+    const requestIdHeader = request.headers['x-request-id'];
+    const requestId =
+      typeof requestIdHeader === 'string'
+        ? requestIdHeader
+        : Array.isArray(requestIdHeader)
+          ? requestIdHeader[0]
+          : undefined;
 
     // ── 1. AppError (custom domain errors) ─────────────────────────
     if (exception instanceof AppError) {
@@ -75,6 +83,7 @@ export class AllExceptionsFilter implements ExceptionFilter {
         errorCode: exception.code,
         path,
         timestamp,
+        requestId,
       };
     }
 
@@ -99,6 +108,7 @@ export class AllExceptionsFilter implements ExceptionFilter {
         errorCode: this.mapHttpStatusToErrorCode(status),
         path,
         timestamp,
+        requestId,
       };
     }
 
@@ -110,6 +120,7 @@ export class AllExceptionsFilter implements ExceptionFilter {
       errorCode: ErrorCode.INTERNAL_ERROR,
       path,
       timestamp,
+      requestId,
     };
   }
 
@@ -180,7 +191,10 @@ export class AllExceptionsFilter implements ExceptionFilter {
     errorResponse: StandardErrorResponse,
   ): void {
     const { statusCode, errorCode, path, message } = errorResponse;
-    const logContext = `${errorCode} | ${path}`;
+    const requestInfo = errorResponse.requestId
+      ? ` | requestId=${errorResponse.requestId}`
+      : '';
+    const logContext = `${errorCode} | ${path}${requestInfo}`;
 
     if (statusCode >= 500) {
       // Server errors — log with stack trace

--- a/src/common/request-context.ts
+++ b/src/common/request-context.ts
@@ -1,0 +1,21 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+export interface RequestContextStore {
+  requestId: string;
+}
+
+const requestContextStorage = new AsyncLocalStorage<RequestContextStore>();
+
+export class RequestContext {
+  static run<T>(store: RequestContextStore, callback: () => T): T {
+    return requestContextStorage.run(store, callback);
+  }
+
+  static getStore(): RequestContextStore | undefined {
+    return requestContextStorage.getStore();
+  }
+
+  static getRequestId(): string | undefined {
+    return requestContextStorage.getStore()?.requestId;
+  }
+}

--- a/src/common/request-id.middleware.spec.ts
+++ b/src/common/request-id.middleware.spec.ts
@@ -1,0 +1,66 @@
+import { randomUUID } from 'crypto';
+import { EventEmitter } from 'events';
+import { RequestIdMiddleware } from './request-id.middleware';
+import { RequestContext } from './request-context';
+
+jest.mock('crypto', () => ({
+  randomUUID: jest.fn(),
+}));
+
+describe('RequestIdMiddleware', () => {
+  const middleware = new RequestIdMiddleware();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should reuse incoming x-request-id header', () => {
+    const req: any = {
+      headers: { 'x-request-id': 'incoming-id' },
+      header: jest.fn((name: string) => req.headers[name]),
+    };
+    const res: any = new EventEmitter();
+    res.setHeader = jest.fn();
+    const next = jest.fn();
+
+    middleware.use(req, res, next);
+
+    expect(req.headers['x-request-id']).toBe('incoming-id');
+    expect(res.setHeader).toHaveBeenCalledWith('X-Request-ID', 'incoming-id');
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('should generate x-request-id when header is missing', () => {
+    (randomUUID as jest.Mock).mockReturnValue('generated-id');
+
+    const req: any = {
+      headers: {},
+      header: jest.fn(() => undefined),
+    };
+    const res: any = new EventEmitter();
+    res.setHeader = jest.fn();
+    const next = jest.fn();
+
+    middleware.use(req, res, next);
+
+    expect(req.headers['x-request-id']).toBe('generated-id');
+    expect(res.setHeader).toHaveBeenCalledWith('X-Request-ID', 'generated-id');
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('should expose requestId in async request context', () => {
+    const req: any = {
+      headers: { 'x-request-id': 'ctx-id' },
+      header: jest.fn((name: string) => req.headers[name]),
+    };
+    const res: any = new EventEmitter();
+    res.setHeader = jest.fn();
+
+    let capturedRequestId: string | undefined;
+    middleware.use(req, res, () => {
+      capturedRequestId = RequestContext.getRequestId();
+    });
+
+    expect(capturedRequestId).toBe('ctx-id');
+  });
+});

--- a/src/common/request-id.middleware.ts
+++ b/src/common/request-id.middleware.ts
@@ -1,0 +1,22 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import { NextFunction, Request, Response } from 'express';
+import { RequestContext } from './request-context';
+
+const REQUEST_ID_HEADER = 'x-request-id';
+
+@Injectable()
+export class RequestIdMiddleware implements NestMiddleware {
+  use(req: Request, res: Response, next: NextFunction) {
+    const incomingRequestId = req.header(REQUEST_ID_HEADER);
+    const requestId =
+      typeof incomingRequestId === 'string' && incomingRequestId.trim().length > 0
+        ? incomingRequestId.trim()
+        : randomUUID();
+
+    req.headers[REQUEST_ID_HEADER] = requestId;
+    res.setHeader('X-Request-ID', requestId);
+
+    RequestContext.run({ requestId }, () => next());
+  }
+}

--- a/src/common/services/app-logger.service.spec.ts
+++ b/src/common/services/app-logger.service.spec.ts
@@ -11,6 +11,7 @@
 import { Test } from '@nestjs/testing';
 import { AppLoggerService } from './app-logger.service';
 import { ConfigService } from '@nestjs/config';
+import { RequestContext } from '../request-context';
 
 function buildModule(logLevel: string, timestamp = true, colors = true) {
   const mockConfigService = {
@@ -145,6 +146,24 @@ describe('AppLoggerService', () => {
         .mockImplementation(() => {});
       s.log('msg', 'MyContext');
       expect(spy).toHaveBeenCalledWith('msg', 'MyContext');
+      spy.mockRestore();
+    });
+
+    it('should include requestId from request context in log message', async () => {
+      const module = await buildModule('info');
+      const s = await module.resolve(AppLoggerService);
+      const spy = jest
+        .spyOn(Object.getPrototypeOf(Object.getPrototypeOf(s)), 'log')
+        .mockImplementation(() => {});
+
+      RequestContext.run({ requestId: 'req-ctx-1' }, () => {
+        s.log('test message');
+      });
+
+      expect(spy).toHaveBeenCalledWith(
+        '[requestId=req-ctx-1] test message',
+        undefined,
+      );
       spy.mockRestore();
     });
   });

--- a/src/common/services/app-logger.service.ts
+++ b/src/common/services/app-logger.service.ts
@@ -11,6 +11,7 @@
 
 import { Injectable, Logger, LoggerService, Scope } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { RequestContext } from '../request-context';
 
 @Injectable({ scope: Scope.TRANSIENT })
 export class AppLoggerService extends Logger implements LoggerService {
@@ -79,7 +80,7 @@ export class AppLoggerService extends Logger implements LoggerService {
    */
   log(message: any, context?: string) {
     if (this.enabledLevels.has('log')) {
-      super.log(message, context || this.context);
+      super.log(this.withRequestId(message), context || this.context);
     }
   }
 
@@ -88,7 +89,7 @@ export class AppLoggerService extends Logger implements LoggerService {
    */
   error(message: any, trace?: string, context?: string) {
     if (this.enabledLevels.has('error')) {
-      super.error(message, trace, context || this.context);
+      super.error(this.withRequestId(message), trace, context || this.context);
     }
   }
 
@@ -97,7 +98,7 @@ export class AppLoggerService extends Logger implements LoggerService {
    */
   warn(message: any, context?: string) {
     if (this.enabledLevels.has('warn')) {
-      super.warn(message, context || this.context);
+      super.warn(this.withRequestId(message), context || this.context);
     }
   }
 
@@ -106,7 +107,7 @@ export class AppLoggerService extends Logger implements LoggerService {
    */
   debug(message: any, context?: string) {
     if (this.enabledLevels.has('debug')) {
-      super.debug(message, context || this.context);
+      super.debug(this.withRequestId(message), context || this.context);
     }
   }
 
@@ -115,8 +116,25 @@ export class AppLoggerService extends Logger implements LoggerService {
    */
   verbose(message: any, context?: string) {
     if (this.enabledLevels.has('verbose')) {
-      super.verbose(message, context || this.context);
+      super.verbose(this.withRequestId(message), context || this.context);
     }
+  }
+
+  private withRequestId(message: any): any {
+    const requestId = RequestContext.getRequestId();
+    if (!requestId) {
+      return message;
+    }
+
+    if (typeof message === 'string') {
+      return `[requestId=${requestId}] ${message}`;
+    }
+
+    if (message && typeof message === 'object') {
+      return { requestId, ...message };
+    }
+
+    return `[requestId=${requestId}] ${String(message)}`;
   }
 
   /**

--- a/src/metrics/business-metrics.interceptor.spec.ts
+++ b/src/metrics/business-metrics.interceptor.spec.ts
@@ -205,6 +205,22 @@ describe('BusinessMetricsInterceptor', () => {
     });
   });
 
+  it('should normalize dynamic route when tracking errors', (done) => {
+    const ctx = buildContext('/inspections/123?include=details');
+    const error = new Error('broken');
+    error.name = 'BadRequestError';
+
+    interceptor.intercept(ctx, buildErrorHandler(error)).subscribe({
+      error: () => {
+        expect(metricsService.incrementError).toHaveBeenCalledWith(
+          'BadRequestError',
+          '/inspections/:id',
+        );
+        done();
+      },
+    });
+  });
+
   it('should not call any metrics for untracked endpoints', (done) => {
     const ctx = buildContext('/health');
     interceptor.intercept(ctx, buildHandler({})).subscribe({

--- a/src/metrics/business-metrics.interceptor.ts
+++ b/src/metrics/business-metrics.interceptor.ts
@@ -16,6 +16,10 @@ interface SyncData {
   syncPercentage?: number;
 }
 
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const HEX_REGEX = /^[0-9a-f]{16,}$/i;
+
 @Injectable()
 export class BusinessMetricsInterceptor implements NestInterceptor {
   constructor(private readonly metricsService: MetricsService) {}
@@ -32,13 +36,43 @@ export class BusinessMetricsInterceptor implements NestInterceptor {
       catchError((error: Error) => {
         // Track failed operations
         this.trackBusinessMetrics(endpoint, 'failure', null);
+        const normalizedRoute = this.normalizeRoute(endpoint);
         this.metricsService.incrementError(
           error.name || 'UnknownError',
-          endpoint,
+          normalizedRoute,
         );
         throw error;
       }),
     );
+  }
+
+  private normalizeRoute(url: string): string {
+    const path = url.split('?')[0] || '/unknown';
+
+    const segments = path
+      .split('/')
+      .filter(Boolean)
+      .map((segment) => {
+        if (segment.startsWith(':')) {
+          return segment;
+        }
+
+        if (/^\d+$/.test(segment)) {
+          return ':id';
+        }
+
+        if (UUID_REGEX.test(segment)) {
+          return ':uuid';
+        }
+
+        if (HEX_REGEX.test(segment)) {
+          return ':hash';
+        }
+
+        return segment;
+      });
+
+    return `/${segments.join('/')}`;
   }
 
   private trackBusinessMetrics(endpoint: string, status: string, data: any) {

--- a/src/metrics/metrics.middleware.spec.ts
+++ b/src/metrics/metrics.middleware.spec.ts
@@ -60,6 +60,31 @@ describe('MetricsMiddleware', () => {
     expect(metricsService.decrementActiveConnections).toHaveBeenCalledTimes(1);
   });
 
+  it('should decrement active connections on close without recording HTTP metrics', () => {
+    const req: any = { method: 'GET', path: '/api/v1/inspections/123' };
+    const res: any = new EventEmitter();
+    res.statusCode = 499;
+
+    middleware.use(req, res, jest.fn());
+    res.emit('close');
+
+    expect(metricsService.decrementActiveConnections).toHaveBeenCalledTimes(1);
+    expect(metricsService.incrementHttpRequests).not.toHaveBeenCalled();
+    expect(metricsService.observeHttpDuration).not.toHaveBeenCalled();
+  });
+
+  it('should decrement active connections only once when finish and close both fire', () => {
+    const req: any = { method: 'GET', path: '/api/v1/inspections/123' };
+    const res: any = new EventEmitter();
+    res.statusCode = 200;
+
+    middleware.use(req, res, jest.fn());
+    res.emit('finish');
+    res.emit('close');
+
+    expect(metricsService.decrementActiveConnections).toHaveBeenCalledTimes(1);
+  });
+
   it('should normalize dynamic numeric routes to :id', () => {
     const req: any = { method: 'GET', path: '/api/v1/inspections/123' };
     const res: any = new EventEmitter();

--- a/src/metrics/metrics.middleware.spec.ts
+++ b/src/metrics/metrics.middleware.spec.ts
@@ -13,9 +13,11 @@ describe('MetricsMiddleware', () => {
 
   beforeEach(() => {
     metricsService = {
-      setActiveConnections: jest.fn(),
+      incrementActiveConnections: jest.fn(),
+      decrementActiveConnections: jest.fn(),
       incrementHttpRequests: jest.fn(),
       observeHttpDuration: jest.fn(),
+      incrementHttpErrors: jest.fn(),
     };
     middleware = new MetricsMiddleware(metricsService as MetricsService);
   });
@@ -24,7 +26,7 @@ describe('MetricsMiddleware', () => {
     expect(middleware).toBeDefined();
   });
 
-  it('should call setActiveConnections(1) immediately on request', () => {
+  it('should increment active connections immediately on request', () => {
     const req: any = { method: 'GET', path: '/api/test' };
     const res: any = new EventEmitter();
     res.statusCode = 200;
@@ -32,11 +34,11 @@ describe('MetricsMiddleware', () => {
 
     middleware.use(req, res, next);
 
-    expect(metricsService.setActiveConnections).toHaveBeenCalledWith(1);
+    expect(metricsService.incrementActiveConnections).toHaveBeenCalledTimes(1);
     expect(next).toHaveBeenCalledTimes(1);
   });
 
-  it('should record HTTP metrics and reset connections on response finish', () => {
+  it('should record HTTP metrics and decrement active connections', () => {
     const req: any = { method: 'POST', path: '/api/inspections' };
     const res: any = new EventEmitter();
     res.statusCode = 201;
@@ -48,15 +50,44 @@ describe('MetricsMiddleware', () => {
     expect(metricsService.incrementHttpRequests).toHaveBeenCalledWith(
       'POST',
       '/api/inspections',
-      '201',
+      '2xx',
     );
     expect(metricsService.observeHttpDuration).toHaveBeenCalledWith(
       'POST',
       '/api/inspections',
-      '201',
       expect.any(Number),
     );
-    expect(metricsService.setActiveConnections).toHaveBeenCalledWith(0);
+    expect(metricsService.decrementActiveConnections).toHaveBeenCalledTimes(1);
+  });
+
+  it('should normalize dynamic numeric routes to :id', () => {
+    const req: any = { method: 'GET', path: '/api/v1/inspections/123' };
+    const res: any = new EventEmitter();
+    res.statusCode = 200;
+
+    middleware.use(req, res, jest.fn());
+    res.emit('finish');
+
+    expect(metricsService.incrementHttpRequests).toHaveBeenCalledWith(
+      'GET',
+      '/api/v1/inspections/:id',
+      '2xx',
+    );
+  });
+
+  it('should increment HTTP error counter for client errors', () => {
+    const req: any = { method: 'GET', path: '/api/v1/inspections/1' };
+    const res: any = new EventEmitter();
+    res.statusCode = 404;
+
+    middleware.use(req, res, jest.fn());
+    res.emit('finish');
+
+    expect(metricsService.incrementHttpErrors).toHaveBeenCalledWith(
+      'GET',
+      '/api/v1/inspections/:id',
+      'client_error',
+    );
   });
 
   it('should call next() to pass to next middleware', () => {
@@ -81,7 +112,7 @@ describe('MetricsMiddleware', () => {
 
     const call = (metricsService.observeHttpDuration as jest.Mock).mock
       .calls[0];
-    const duration = call[3];
+    const duration = call[2];
     expect(duration).toBeGreaterThanOrEqual(0);
   });
 });

--- a/src/metrics/metrics.middleware.ts
+++ b/src/metrics/metrics.middleware.ts
@@ -17,10 +17,21 @@ export class MetricsMiddleware implements NestMiddleware {
 
   use(req: Request, res: Response, next: NextFunction) {
     const startTime = process.hrtime.bigint();
+    let finalized = false;
 
     this.metricsService.incrementActiveConnections();
 
-    res.on('finish', () => {
+    const cleanup = () => {
+      res.removeListener('finish', onFinish);
+      res.removeListener('close', onClose);
+    };
+
+    const onFinish = () => {
+      if (finalized) {
+        return;
+      }
+      finalized = true;
+
       const elapsedNs = process.hrtime.bigint() - startTime;
       const duration = Number(elapsedNs) / 1_000_000_000;
       const route = this.resolveRouteTemplate(req as RequestWithRoute);
@@ -37,7 +48,20 @@ export class MetricsMiddleware implements NestMiddleware {
       }
 
       this.metricsService.decrementActiveConnections();
-    });
+      cleanup();
+    };
+
+    const onClose = () => {
+      if (finalized) {
+        return;
+      }
+      finalized = true;
+      this.metricsService.decrementActiveConnections();
+      cleanup();
+    };
+
+    res.on('finish', onFinish);
+    res.on('close', onClose);
 
     next();
   }

--- a/src/metrics/metrics.middleware.ts
+++ b/src/metrics/metrics.middleware.ts
@@ -2,30 +2,87 @@ import { Injectable, NestMiddleware } from '@nestjs/common';
 import { Request, Response, NextFunction } from 'express';
 import { MetricsService } from './metrics.service';
 
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const HEX_REGEX = /^[0-9a-f]{16,}$/i;
+
+type RequestWithRoute = Request & {
+  baseUrl?: string;
+  route?: { path?: string | string[] };
+};
+
 @Injectable()
 export class MetricsMiddleware implements NestMiddleware {
   constructor(private readonly metricsService: MetricsService) {}
 
   use(req: Request, res: Response, next: NextFunction) {
-    const startTime = Date.now();
+    const startTime = process.hrtime.bigint();
 
-    // Count active connections
-    this.metricsService.setActiveConnections(1);
+    this.metricsService.incrementActiveConnections();
 
     res.on('finish', () => {
-      const duration = (Date.now() - startTime) / 1000;
-      const route = String(req.path);
+      const elapsedNs = process.hrtime.bigint() - startTime;
+      const duration = Number(elapsedNs) / 1_000_000_000;
+      const route = this.resolveRouteTemplate(req as RequestWithRoute);
       const method = req.method;
-      const status = res.statusCode.toString();
+      const statusClass = this.getStatusClass(res.statusCode);
 
-      // Record HTTP metrics
-      this.metricsService.incrementHttpRequests(method, route, status);
-      this.metricsService.observeHttpDuration(method, route, status, duration);
+      this.metricsService.incrementHttpRequests(method, route, statusClass);
+      this.metricsService.observeHttpDuration(method, route, duration);
 
-      // Reset active connections (simplified)
-      this.metricsService.setActiveConnections(0);
+      if (res.statusCode >= 400) {
+        const errorType =
+          res.statusCode >= 500 ? 'server_error' : 'client_error';
+        this.metricsService.incrementHttpErrors(method, route, errorType);
+      }
+
+      this.metricsService.decrementActiveConnections();
     });
 
     next();
+  }
+
+  private getStatusClass(statusCode: number): string {
+    return `${Math.floor(statusCode / 100)}xx`;
+  }
+
+  private resolveRouteTemplate(req: RequestWithRoute): string {
+    if (req.route?.path) {
+      const routePath = Array.isArray(req.route.path)
+        ? req.route.path[0]
+        : req.route.path;
+
+      return this.normalizeRoute(`${req.baseUrl || ''}${routePath || ''}`);
+    }
+
+    const path = req.originalUrl?.split('?')[0] || req.path || '/unknown';
+    return this.normalizeRoute(path);
+  }
+
+  private normalizeRoute(path: string): string {
+    const segments = path
+      .split('/')
+      .filter(Boolean)
+      .map((segment) => {
+        if (segment.startsWith(':')) {
+          return segment;
+        }
+
+        if (segment.length > 0 && /^\d+$/.test(segment)) {
+          return ':id';
+        }
+
+        if (UUID_REGEX.test(segment)) {
+          return ':uuid';
+        }
+
+        if (HEX_REGEX.test(segment)) {
+          return ':hash';
+        }
+
+        return segment;
+      });
+
+    return `/${segments.join('/') || ''}`;
   }
 }

--- a/src/metrics/metrics.service.spec.ts
+++ b/src/metrics/metrics.service.spec.ts
@@ -32,14 +32,14 @@ describe('MetricsService', () => {
   describe('incrementHttpRequests', () => {
     it('should increment httpRequestsTotal counter without throwing', () => {
       expect(() =>
-        service.incrementHttpRequests('GET', '/api/v1/users', '200'),
+        service.incrementHttpRequests('GET', '/api/v1/users', '2xx'),
       ).not.toThrow();
     });
 
     it('should handle multiple calls with different labels', () => {
-      service.incrementHttpRequests('POST', '/api/v1/inspections', '201');
-      service.incrementHttpRequests('GET', '/api/v1/inspections', '200');
-      service.incrementHttpRequests('DELETE', '/api/v1/inspections/1', '404');
+      service.incrementHttpRequests('POST', '/api/v1/inspections', '2xx');
+      service.incrementHttpRequests('GET', '/api/v1/inspections', '2xx');
+      service.incrementHttpRequests('DELETE', '/api/v1/inspections/:id', '4xx');
       // No assertion on values — just ensure no errors thrown
     });
   });
@@ -47,20 +47,24 @@ describe('MetricsService', () => {
   // ---------------------------------------------------------------------------
   describe('observeHttpDuration', () => {
     it('should observe http request duration without throwing', () => {
-      expect(() =>
-        service.observeHttpDuration('GET', '/api/health', '200', 0.123),
-      ).not.toThrow();
+      expect(() => service.observeHttpDuration('GET', '/api/health', 0.123)).not
+        .toThrow();
     });
 
     it('should accept zero duration', () => {
-      expect(() =>
-        service.observeHttpDuration('GET', '/fast', '200', 0),
-      ).not.toThrow();
+      expect(() => service.observeHttpDuration('GET', '/fast', 0)).not.toThrow();
     });
 
     it('should accept large duration values', () => {
+      expect(() => service.observeHttpDuration('POST', '/slow', 15.5)).not.toThrow();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  describe('incrementHttpErrors', () => {
+    it('should increment HTTP error counter without throwing', () => {
       expect(() =>
-        service.observeHttpDuration('POST', '/slow', '500', 15.5),
+        service.incrementHttpErrors('GET', '/api/v1/users/:id', 'client_error'),
       ).not.toThrow();
     });
   });

--- a/src/metrics/metrics.service.ts
+++ b/src/metrics/metrics.service.ts
@@ -3,8 +3,11 @@ import { Counter, Histogram, Gauge, register } from 'prom-client';
 
 @Injectable()
 export class MetricsService {
+  private readonly serviceName: string;
+  private readonly environment: string;
   private readonly httpRequestsTotal: Counter<string>;
   private readonly httpRequestDuration: Histogram<string>;
+  private readonly httpRequestErrorsTotal: Counter<string>;
   private readonly activeConnections: Gauge<string>;
   private readonly databaseConnections: Gauge<string>;
   private readonly walletOperations: Counter<string>;
@@ -13,18 +16,27 @@ export class MetricsService {
   private readonly errorCount: Counter<string>;
 
   constructor() {
+    this.serviceName = process.env.OBS_SERVICE_NAME || 'cardano-backend';
+    this.environment = process.env.OBS_ENV || process.env.NODE_ENV || 'development';
+
     // HTTP Metrics
     this.httpRequestsTotal = new Counter({
       name: 'http_requests_total',
       help: 'Total number of HTTP requests',
-      labelNames: ['method', 'route', 'status'],
+      labelNames: ['service', 'env', 'method', 'route', 'status_class'],
     });
 
     this.httpRequestDuration = new Histogram({
       name: 'http_request_duration_seconds',
       help: 'Duration of HTTP requests in seconds',
-      labelNames: ['method', 'route', 'status'],
-      buckets: [0.1, 0.5, 1, 2, 5, 10],
+      labelNames: ['service', 'env', 'method', 'route'],
+      buckets: [0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10],
+    });
+
+    this.httpRequestErrorsTotal = new Counter({
+      name: 'http_request_errors_total',
+      help: 'Total number of HTTP request errors',
+      labelNames: ['service', 'env', 'method', 'route', 'error_type'],
     });
 
     this.activeConnections = new Gauge({
@@ -59,12 +71,13 @@ export class MetricsService {
     this.errorCount = new Counter({
       name: 'application_errors_total',
       help: 'Total application errors',
-      labelNames: ['error_type', 'endpoint'],
+      labelNames: ['service', 'env', 'error_type', 'route'],
     });
 
     // Register all metrics
     register.registerMetric(this.httpRequestsTotal);
     register.registerMetric(this.httpRequestDuration);
+    register.registerMetric(this.httpRequestErrorsTotal);
     register.registerMetric(this.activeConnections);
     register.registerMetric(this.databaseConnections);
     register.registerMetric(this.walletOperations);
@@ -74,21 +87,52 @@ export class MetricsService {
   }
 
   // HTTP Metrics Methods
-  incrementHttpRequests(method: string, route: string, status: string) {
-    this.httpRequestsTotal.inc({ method, route, status });
+  incrementHttpRequests(method: string, route: string, statusClass: string) {
+    this.httpRequestsTotal.inc({
+      service: this.serviceName,
+      env: this.environment,
+      method,
+      route,
+      status_class: statusClass,
+    });
   }
 
-  observeHttpDuration(
+  observeHttpDuration(method: string, route: string, duration: number) {
+    this.httpRequestDuration.observe(
+      {
+        service: this.serviceName,
+        env: this.environment,
+        method,
+        route,
+      },
+      duration,
+    );
+  }
+
+  incrementHttpErrors(
     method: string,
     route: string,
-    status: string,
-    duration: number,
+    errorType: string,
   ) {
-    this.httpRequestDuration.observe({ method, route, status }, duration);
+    this.httpRequestErrorsTotal.inc({
+      service: this.serviceName,
+      env: this.environment,
+      method,
+      route,
+      error_type: errorType,
+    });
   }
 
   setActiveConnections(count: number) {
     this.activeConnections.set(count);
+  }
+
+  incrementActiveConnections() {
+    this.activeConnections.inc();
+  }
+
+  decrementActiveConnections() {
+    this.activeConnections.dec();
   }
 
   // Database Metrics Methods
@@ -110,8 +154,13 @@ export class MetricsService {
   }
 
   // Error Metrics Methods
-  incrementError(errorType: string, endpoint: string) {
-    this.errorCount.inc({ error_type: errorType, endpoint });
+  incrementError(errorType: string, route: string) {
+    this.errorCount.inc({
+      service: this.serviceName,
+      env: this.environment,
+      error_type: errorType,
+      route,
+    });
   }
 
   // Get all metrics


### PR DESCRIPTION
## Summary
- implement Sprint 1 observability foundations in `cardano-backend` with request ID middleware and async request context propagation
- upgrade RED metrics to contract-compliant labels (`service`, `env`, normalized `route`, `status_class`) and add `http_request_errors_total`
- add telemetry contract documentation and update tests to validate route normalization, error counters, and request ID propagation

## Why
Sprint 1 needs a stable, low-cardinality telemetry baseline so monitoring dashboards and alerts can be trusted as we move into tracing and infra rollout.

## Changes
- **Correlation ID**
  - add `RequestIdMiddleware` to accept/generate `x-request-id`
  - echo `X-Request-ID` in responses
  - add `RequestContext` (`AsyncLocalStorage`) for per-request propagation
- **Metrics (RED baseline)**
  - update `http_requests_total` labels to `{service,env,method,route,status_class}`
  - update `http_request_duration_seconds` labels to `{service,env,method,route}`
  - add `http_request_errors_total{service,env,method,route,error_type}`
  - normalize route labels (`:id`, `:uuid`, `:hash`) to prevent cardinality explosions
- **Error and logging correlation**
  - include `requestId` in standardized exception response payload
  - include `requestId` in `AllExceptionsFilter` log context
  - include `requestId` in `AppLoggerService` output when context is available
- **Docs**
  - add `docs/observability/telemetry-contract.md`

## Validation
- `npm test -- src/metrics/metrics.service.spec.ts src/metrics/metrics.middleware.spec.ts src/metrics/business-metrics.interceptor.spec.ts src/common/request-id.middleware.spec.ts src/common/services/app-logger.service.spec.ts src/common/filters/all-exceptions.filter.spec.ts`
- `npm run build`

## Linked Issues
Closes #126
Closes #127
Closes #128
Refs #124
Refs #123
Refs #130