### PR TITLE
fix(metrics): harden /metrics endpoint and scrape behavior

### DIFF
--- a/docs/observability/telemetry-contract.md
+++ b/docs/observability/telemetry-contract.md
@@ -86,11 +86,27 @@ Sprint 2 extends to full structured JSON logging with `traceId` and `spanId` cor
 
 - Endpoint: `GET /api/v1/metrics`
 - Content type: `text/plain`
+- Response header: `Cache-Control: no-store`
 - Intended scraper: Prometheus
 - Recommended scrape config:
   - interval: `15s`
   - timeout: `5s`
-- Access control: enforce at reverse proxy/network layer (internal allowlist/basic auth)
+- Access control (defense in depth):
+  - network/reverse proxy allowlist + auth
+  - app-layer `MetricsAuthGuard` (bearer or basic auth)
+
+### Security env vars for `/metrics`
+
+- `METRICS_ENABLED` (optional, default enabled; set `false` to disable endpoint)
+- `METRICS_BEARER_TOKEN` (optional)
+- `METRICS_BASIC_AUTH_USER` (optional)
+- `METRICS_BASIC_AUTH_PASSWORD` (optional)
+
+Security behavior:
+
+- In `production` with no auth configured, app-layer guard denies access.
+- In non-production with no auth configured, endpoint is allowed for local development.
+- If bearer/basic auth is configured, valid `Authorization` header is required.
 
 ## Validation checklist
 

--- a/src/metrics/metrics-auth.guard.spec.ts
+++ b/src/metrics/metrics-auth.guard.spec.ts
@@ -1,4 +1,4 @@
-import { ExecutionContext } from '@nestjs/common';
+import { ExecutionContext, NotFoundException } from '@nestjs/common';
 import { MetricsAuthGuard } from './metrics-auth.guard';
 
 function buildExecutionContext(
@@ -25,6 +25,7 @@ describe('MetricsAuthGuard', () => {
     delete process.env.METRICS_BASIC_AUTH_USER;
     delete process.env.METRICS_BASIC_AUTH_PASSWORD;
     delete process.env.NODE_ENV;
+    delete process.env.METRICS_ENABLED;
 
     guard = new MetricsAuthGuard();
   });
@@ -45,6 +46,14 @@ describe('MetricsAuthGuard', () => {
     expect(guard.canActivate(buildExecutionContext())).toBe(false);
   });
 
+  it('throws 404 when metrics are explicitly disabled', () => {
+    process.env.METRICS_ENABLED = 'false';
+
+    expect(() => guard.canActivate(buildExecutionContext())).toThrow(
+      NotFoundException,
+    );
+  });
+
   it('allows valid bearer token', () => {
     process.env.METRICS_BEARER_TOKEN = 'secret-token';
 
@@ -59,6 +68,14 @@ describe('MetricsAuthGuard', () => {
     expect(
       guard.canActivate(buildExecutionContext('Bearer invalid-token')),
     ).toBe(false);
+  });
+
+  it('accepts lowercase bearer scheme', () => {
+    process.env.METRICS_BEARER_TOKEN = 'secret-token';
+
+    expect(
+      guard.canActivate(buildExecutionContext('bearer secret-token')),
+    ).toBe(true);
   });
 
   it('allows valid basic auth credentials', () => {
@@ -78,6 +95,16 @@ describe('MetricsAuthGuard', () => {
     const encoded = Buffer.from('metrics:wrong-password').toString('base64');
     expect(guard.canActivate(buildExecutionContext(`Basic ${encoded}`))).toBe(
       false,
+    );
+  });
+
+  it('accepts lowercase basic scheme', () => {
+    process.env.METRICS_BASIC_AUTH_USER = 'metrics';
+    process.env.METRICS_BASIC_AUTH_PASSWORD = 'strong-password';
+
+    const encoded = Buffer.from('metrics:strong-password').toString('base64');
+    expect(guard.canActivate(buildExecutionContext(`basic ${encoded}`))).toBe(
+      true,
     );
   });
 });

--- a/src/metrics/metrics-auth.guard.spec.ts
+++ b/src/metrics/metrics-auth.guard.spec.ts
@@ -1,0 +1,83 @@
+import { ExecutionContext } from '@nestjs/common';
+import { MetricsAuthGuard } from './metrics-auth.guard';
+
+function buildExecutionContext(
+  authorization?: string,
+): ExecutionContext {
+  return {
+    switchToHttp: () => ({
+      getRequest: () => ({
+        headers: {
+          authorization,
+        },
+      }),
+    }),
+  } as unknown as ExecutionContext;
+}
+
+describe('MetricsAuthGuard', () => {
+  const originalEnv = process.env;
+  let guard: MetricsAuthGuard;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.METRICS_BEARER_TOKEN;
+    delete process.env.METRICS_BASIC_AUTH_USER;
+    delete process.env.METRICS_BASIC_AUTH_PASSWORD;
+    delete process.env.NODE_ENV;
+
+    guard = new MetricsAuthGuard();
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('allows access in non-production when no auth is configured', () => {
+    process.env.NODE_ENV = 'development';
+
+    expect(guard.canActivate(buildExecutionContext())).toBe(true);
+  });
+
+  it('denies access in production when no auth is configured', () => {
+    process.env.NODE_ENV = 'production';
+
+    expect(guard.canActivate(buildExecutionContext())).toBe(false);
+  });
+
+  it('allows valid bearer token', () => {
+    process.env.METRICS_BEARER_TOKEN = 'secret-token';
+
+    expect(
+      guard.canActivate(buildExecutionContext('Bearer secret-token')),
+    ).toBe(true);
+  });
+
+  it('denies invalid bearer token', () => {
+    process.env.METRICS_BEARER_TOKEN = 'secret-token';
+
+    expect(
+      guard.canActivate(buildExecutionContext('Bearer invalid-token')),
+    ).toBe(false);
+  });
+
+  it('allows valid basic auth credentials', () => {
+    process.env.METRICS_BASIC_AUTH_USER = 'metrics';
+    process.env.METRICS_BASIC_AUTH_PASSWORD = 'strong-password';
+
+    const encoded = Buffer.from('metrics:strong-password').toString('base64');
+    expect(guard.canActivate(buildExecutionContext(`Basic ${encoded}`))).toBe(
+      true,
+    );
+  });
+
+  it('denies invalid basic auth credentials', () => {
+    process.env.METRICS_BASIC_AUTH_USER = 'metrics';
+    process.env.METRICS_BASIC_AUTH_PASSWORD = 'strong-password';
+
+    const encoded = Buffer.from('metrics:wrong-password').toString('base64');
+    expect(guard.canActivate(buildExecutionContext(`Basic ${encoded}`))).toBe(
+      false,
+    );
+  });
+});

--- a/src/metrics/metrics-auth.guard.ts
+++ b/src/metrics/metrics-auth.guard.ts
@@ -1,8 +1,18 @@
-import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 
 @Injectable()
 export class MetricsAuthGuard implements CanActivate {
   canActivate(context: ExecutionContext): boolean {
+    const metricsEnabled = process.env.METRICS_ENABLED;
+    if (metricsEnabled && metricsEnabled.toLowerCase() === 'false') {
+      throw new NotFoundException('Metrics endpoint is disabled');
+    }
+
     const request = context.switchToHttp().getRequest<{
       headers?: Record<string, string | string[] | undefined>;
     }>();
@@ -59,7 +69,7 @@ export class MetricsAuthGuard implements CanActivate {
 
   private isValidBearer(authorization: string, expectedToken: string): boolean {
     const [scheme, token] = authorization.split(' ');
-    return scheme === 'Bearer' && token === expectedToken;
+    return scheme?.toLowerCase() === 'bearer' && token === expectedToken;
   }
 
   private isValidBasic(
@@ -68,7 +78,7 @@ export class MetricsAuthGuard implements CanActivate {
     expectedPassword: string,
   ): boolean {
     const [scheme, encoded] = authorization.split(' ');
-    if (scheme !== 'Basic' || !encoded) {
+    if (scheme?.toLowerCase() !== 'basic' || !encoded) {
       return false;
     }
 

--- a/src/metrics/metrics-auth.guard.ts
+++ b/src/metrics/metrics-auth.guard.ts
@@ -1,0 +1,85 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+
+@Injectable()
+export class MetricsAuthGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest<{
+      headers?: Record<string, string | string[] | undefined>;
+    }>();
+
+    const isProduction = (process.env.NODE_ENV || '').toLowerCase() === 'production';
+    const bearerToken = process.env.METRICS_BEARER_TOKEN;
+    const basicUser = process.env.METRICS_BASIC_AUTH_USER;
+    const basicPassword = process.env.METRICS_BASIC_AUTH_PASSWORD;
+
+    const hasBearer = Boolean(bearerToken);
+    const hasBasic = Boolean(basicUser) && Boolean(basicPassword);
+
+    if (!hasBearer && !hasBasic) {
+      return !isProduction;
+    }
+
+    const authorization = this.getAuthorizationHeader(request.headers);
+    if (!authorization) {
+      return false;
+    }
+
+    if (hasBearer && this.isValidBearer(authorization, bearerToken as string)) {
+      return true;
+    }
+
+    if (
+      hasBasic &&
+      this.isValidBasic(
+        authorization,
+        basicUser as string,
+        basicPassword as string,
+      )
+    ) {
+      return true;
+    }
+
+    return false;
+  }
+
+  private getAuthorizationHeader(
+    headers?: Record<string, string | string[] | undefined>,
+  ): string | undefined {
+    if (!headers) {
+      return undefined;
+    }
+
+    const value = headers.authorization;
+    if (Array.isArray(value)) {
+      return value[0];
+    }
+
+    return value;
+  }
+
+  private isValidBearer(authorization: string, expectedToken: string): boolean {
+    const [scheme, token] = authorization.split(' ');
+    return scheme === 'Bearer' && token === expectedToken;
+  }
+
+  private isValidBasic(
+    authorization: string,
+    expectedUser: string,
+    expectedPassword: string,
+  ): boolean {
+    const [scheme, encoded] = authorization.split(' ');
+    if (scheme !== 'Basic' || !encoded) {
+      return false;
+    }
+
+    try {
+      const decoded = Buffer.from(encoded, 'base64').toString('utf-8');
+      const [user, ...rest] = decoded.split(':');
+      const password = rest.join(':');
+
+      return user === expectedUser && password === expectedPassword;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/src/metrics/metrics.controller.spec.ts
+++ b/src/metrics/metrics.controller.spec.ts
@@ -9,9 +9,11 @@
  */
 
 import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
 import { MetricsController } from './metrics.controller';
 import { MetricsService } from './metrics.service';
 import { ThrottlerGuard } from '@nestjs/throttler';
+import { MetricsAuthGuard } from './metrics-auth.guard';
 
 const mockMetricsService = {
   getMetrics: jest.fn(),
@@ -19,18 +21,28 @@ const mockMetricsService = {
 
 describe('MetricsController', () => {
   let controller: MetricsController;
+  const originalEnv = process.env;
 
   beforeEach(async () => {
+    process.env = { ...originalEnv };
+    delete process.env.METRICS_ENABLED;
+
     const module: TestingModule = await Test.createTestingModule({
       controllers: [MetricsController],
       providers: [{ provide: MetricsService, useValue: mockMetricsService }],
     })
       .overrideGuard(ThrottlerGuard)
       .useValue({ canActivate: () => true })
+      .overrideGuard(MetricsAuthGuard)
+      .useValue({ canActivate: () => true })
       .compile();
 
     controller = module.get<MetricsController>(MetricsController);
     jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
   });
 
   it('should be defined', () => {
@@ -56,6 +68,13 @@ process_cpu_user_seconds_total 0.5`;
       );
 
       await expect(controller.getMetrics()).rejects.toThrow('Registry error');
+    });
+
+    it('should return not found when metrics endpoint is disabled', async () => {
+      process.env.METRICS_ENABLED = 'false';
+
+      await expect(controller.getMetrics()).rejects.toThrow(NotFoundException);
+      expect(mockMetricsService.getMetrics).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/metrics/metrics.controller.spec.ts
+++ b/src/metrics/metrics.controller.spec.ts
@@ -9,7 +9,6 @@
  */
 
 import { Test, TestingModule } from '@nestjs/testing';
-import { NotFoundException } from '@nestjs/common';
 import { MetricsController } from './metrics.controller';
 import { MetricsService } from './metrics.service';
 import { ThrottlerGuard } from '@nestjs/throttler';
@@ -25,8 +24,6 @@ describe('MetricsController', () => {
 
   beforeEach(async () => {
     process.env = { ...originalEnv };
-    delete process.env.METRICS_ENABLED;
-
     const module: TestingModule = await Test.createTestingModule({
       controllers: [MetricsController],
       providers: [{ provide: MetricsService, useValue: mockMetricsService }],
@@ -68,13 +65,6 @@ process_cpu_user_seconds_total 0.5`;
       );
 
       await expect(controller.getMetrics()).rejects.toThrow('Registry error');
-    });
-
-    it('should return not found when metrics endpoint is disabled', async () => {
-      process.env.METRICS_ENABLED = 'false';
-
-      await expect(controller.getMetrics()).rejects.toThrow(NotFoundException);
-      expect(mockMetricsService.getMetrics).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/metrics/metrics.controller.ts
+++ b/src/metrics/metrics.controller.ts
@@ -1,7 +1,14 @@
-import { Controller, Get, Header } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Header,
+  NotFoundException,
+  UseGuards,
+} from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
 import { MetricsService } from './metrics.service';
+import { MetricsAuthGuard } from './metrics-auth.guard';
 
 @ApiTags('Metrics')
 @Controller('metrics')
@@ -10,14 +17,25 @@ export class MetricsController {
 
   @Get()
   @Header('Content-Type', 'text/plain')
+  @Header('Cache-Control', 'no-store')
   // Restrict to 10 scrapes/min — Prometheus scrapes every 15s at most, so this is generous
   @Throttle({ default: { limit: 10, ttl: 60000 } })
+  @UseGuards(MetricsAuthGuard)
   @ApiOperation({ summary: 'Get Prometheus metrics' })
   @ApiResponse({
     status: 200,
     description: 'Prometheus metrics in text format',
   })
+  @ApiResponse({
+    status: 404,
+    description: 'Metrics endpoint disabled',
+  })
   async getMetrics(): Promise<string> {
+    const metricsEnabled = process.env.METRICS_ENABLED;
+    if (metricsEnabled && metricsEnabled.toLowerCase() === 'false') {
+      throw new NotFoundException('Metrics endpoint is disabled');
+    }
+
     return await this.metricsService.getMetrics();
   }
 }

--- a/src/metrics/metrics.controller.ts
+++ b/src/metrics/metrics.controller.ts
@@ -2,7 +2,6 @@ import {
   Controller,
   Get,
   Header,
-  NotFoundException,
   UseGuards,
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
@@ -31,11 +30,6 @@ export class MetricsController {
     description: 'Metrics endpoint disabled',
   })
   async getMetrics(): Promise<string> {
-    const metricsEnabled = process.env.METRICS_ENABLED;
-    if (metricsEnabled && metricsEnabled.toLowerCase() === 'false') {
-      throw new NotFoundException('Metrics endpoint is disabled');
-    }
-
     return await this.metricsService.getMetrics();
   }
 }

--- a/src/metrics/metrics.module.ts
+++ b/src/metrics/metrics.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { MetricsController } from './metrics.controller';
 import { MetricsService } from './metrics.service';
+import { MetricsAuthGuard } from './metrics-auth.guard';
 
 @Module({
   controllers: [MetricsController],
-  providers: [MetricsService],
+  providers: [MetricsService, MetricsAuthGuard],
   exports: [MetricsService],
 })
 export class MetricsModule {}


### PR DESCRIPTION
## Summary
- add app-layer defense-in-depth for `/api/v1/metrics` using a dedicated `MetricsAuthGuard`
- support both bearer token and basic auth from environment variables
- implement production fail-closed behavior when no metrics auth credentials are configured
- add `METRICS_ENABLED=false` toggle to disable endpoint and return 404
- add `Cache-Control: no-store` on metrics responses
- update telemetry contract docs with scrape security envs and behavior

## Why
Issue #130 requires metrics scraping to be production-safe and access-controlled. This PR complements network/proxy restrictions with app-layer protection.

## Validation
- `npm test -- src/metrics/metrics-auth.guard.spec.ts src/metrics/metrics.controller.spec.ts src/metrics/metrics.middleware.spec.ts`
- `npm run build`

## Linked Issues
Closes #130
Refs #124