### PR TITLE
feat(logging): implement trace-to-log correlation

### DIFF
--- a/docs/observability/telemetry-contract.md
+++ b/docs/observability/telemetry-contract.md
@@ -82,6 +82,11 @@ Sprint 1 baseline guarantees:
 
 Sprint 2 extends to full structured JSON logging with `traceId` and `spanId` correlation.
 
+Current correlation baseline includes:
+
+- logger output enriched with active span `traceId` and `spanId`
+- standardized error responses include optional `traceId` and `spanId` when span context exists
+
 ## Tracing bootstrap contract (Sprint 2 start)
 
 - OpenTelemetry SDK bootstrap is controlled by `OTEL_ENABLED`

--- a/src/common/filters/all-exceptions.filter.spec.ts
+++ b/src/common/filters/all-exceptions.filter.spec.ts
@@ -11,6 +11,7 @@
  */
 
 import { ArgumentsHost, HttpException, HttpStatus } from '@nestjs/common';
+import { trace } from '@opentelemetry/api';
 import {
   AllExceptionsFilter,
   StandardErrorResponse,
@@ -460,6 +461,23 @@ describe('AllExceptionsFilter', () => {
 
       const body = getResponseBody();
       expect(body.requestId).toBeUndefined();
+    });
+
+    it('should include traceId and spanId when active span exists', () => {
+      const activeSpanSpy = jest.spyOn(trace, 'getActiveSpan').mockReturnValue({
+        spanContext: () => ({
+          traceId: '11111111111111111111111111111111',
+          spanId: '2222222222222222',
+          traceFlags: 1,
+        }),
+      } as any);
+
+      filter.catch(new Error('trace context error'), mockHost);
+
+      const body = getResponseBody();
+      expect(body.traceId).toBeDefined();
+      expect(body.spanId).toBeDefined();
+      activeSpanSpy.mockRestore();
     });
   });
 });

--- a/src/common/filters/all-exceptions.filter.ts
+++ b/src/common/filters/all-exceptions.filter.ts
@@ -22,6 +22,7 @@ import {
   HttpStatus,
   Logger,
 } from '@nestjs/common';
+import { trace } from '@opentelemetry/api';
 import { Request, Response } from 'express';
 import { AppError } from '../errors/app-error';
 import { ErrorCode } from '../errors/error-codes.enum';
@@ -38,6 +39,8 @@ export interface StandardErrorResponse {
   path: string;
   timestamp: string;
   requestId?: string;
+  traceId?: string;
+  spanId?: string;
 }
 
 @Catch()
@@ -73,6 +76,9 @@ export class AllExceptionsFilter implements ExceptionFilter {
         : Array.isArray(requestIdHeader)
           ? requestIdHeader[0]
           : undefined;
+    const spanContext = trace.getActiveSpan()?.spanContext();
+    const traceId = spanContext?.traceId;
+    const spanId = spanContext?.spanId;
 
     // ── 1. AppError (custom domain errors) ─────────────────────────
     if (exception instanceof AppError) {
@@ -84,6 +90,8 @@ export class AllExceptionsFilter implements ExceptionFilter {
         path,
         timestamp,
         requestId,
+        traceId,
+        spanId,
       };
     }
 
@@ -109,6 +117,8 @@ export class AllExceptionsFilter implements ExceptionFilter {
         path,
         timestamp,
         requestId,
+        traceId,
+        spanId,
       };
     }
 
@@ -121,6 +131,8 @@ export class AllExceptionsFilter implements ExceptionFilter {
       path,
       timestamp,
       requestId,
+      traceId,
+      spanId,
     };
   }
 
@@ -194,7 +206,13 @@ export class AllExceptionsFilter implements ExceptionFilter {
     const requestInfo = errorResponse.requestId
       ? ` | requestId=${errorResponse.requestId}`
       : '';
-    const logContext = `${errorCode} | ${path}${requestInfo}`;
+    const traceInfo = errorResponse.traceId
+      ? ` | traceId=${errorResponse.traceId}`
+      : '';
+    const spanInfo = errorResponse.spanId
+      ? ` | spanId=${errorResponse.spanId}`
+      : '';
+    const logContext = `${errorCode} | ${path}${requestInfo}${traceInfo}${spanInfo}`;
 
     if (statusCode >= 500) {
       // Server errors — log with stack trace

--- a/src/common/services/app-logger.service.spec.ts
+++ b/src/common/services/app-logger.service.spec.ts
@@ -11,6 +11,7 @@
 import { Test } from '@nestjs/testing';
 import { AppLoggerService } from './app-logger.service';
 import { ConfigService } from '@nestjs/config';
+import { trace } from '@opentelemetry/api';
 import { RequestContext } from '../request-context';
 
 function buildModule(logLevel: string, timestamp = true, colors = true) {
@@ -164,6 +165,58 @@ describe('AppLoggerService', () => {
         '[requestId=req-ctx-1] test message',
         undefined,
       );
+      spy.mockRestore();
+    });
+
+    it('should include traceId and spanId from active span context', async () => {
+      const module = await buildModule('info');
+      const s = await module.resolve(AppLoggerService);
+      const spy = jest
+        .spyOn(Object.getPrototypeOf(Object.getPrototypeOf(s)), 'log')
+        .mockImplementation(() => {});
+
+      const activeSpanSpy = jest.spyOn(trace, 'getActiveSpan').mockReturnValue({
+        spanContext: () => ({
+          traceId: '0123456789abcdef0123456789abcdef',
+          spanId: '0123456789abcdef',
+          traceFlags: 1,
+        }),
+      } as any);
+
+      s.log('trace message');
+
+      const loggedMessage = spy.mock.calls[0][0] as string;
+      expect(loggedMessage).toContain('traceId=');
+      expect(loggedMessage).toContain('spanId=');
+      expect(loggedMessage).toContain('trace message');
+      activeSpanSpy.mockRestore();
+      spy.mockRestore();
+    });
+
+    it('should include both requestId and trace context when both available', async () => {
+      const module = await buildModule('info');
+      const s = await module.resolve(AppLoggerService);
+      const spy = jest
+        .spyOn(Object.getPrototypeOf(Object.getPrototypeOf(s)), 'log')
+        .mockImplementation(() => {});
+
+      const activeSpanSpy = jest.spyOn(trace, 'getActiveSpan').mockReturnValue({
+        spanContext: () => ({
+          traceId: 'abcdef0123456789abcdef0123456789',
+          spanId: 'abcdef0123456789',
+          traceFlags: 1,
+        }),
+      } as any);
+
+      RequestContext.run({ requestId: 'req-and-trace' }, () => {
+        s.log('combined message');
+      });
+
+      const loggedMessage = spy.mock.calls[0][0] as string;
+      expect(loggedMessage).toContain('requestId=req-and-trace');
+      expect(loggedMessage).toContain('traceId=');
+      expect(loggedMessage).toContain('spanId=');
+      activeSpanSpy.mockRestore();
       spy.mockRestore();
     });
   });

--- a/src/common/services/app-logger.service.ts
+++ b/src/common/services/app-logger.service.ts
@@ -11,6 +11,7 @@
 
 import { Injectable, Logger, LoggerService, Scope } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { trace } from '@opentelemetry/api';
 import { RequestContext } from '../request-context';
 
 @Injectable({ scope: Scope.TRANSIENT })
@@ -122,19 +123,37 @@ export class AppLoggerService extends Logger implements LoggerService {
 
   private withRequestId(message: any): any {
     const requestId = RequestContext.getRequestId();
-    if (!requestId) {
+    const spanContext = trace.getActiveSpan()?.spanContext();
+
+    const correlationParts: string[] = [];
+    if (requestId) {
+      correlationParts.push(`requestId=${requestId}`);
+    }
+    if (spanContext?.traceId) {
+      correlationParts.push(`traceId=${spanContext.traceId}`);
+    }
+    if (spanContext?.spanId) {
+      correlationParts.push(`spanId=${spanContext.spanId}`);
+    }
+
+    if (correlationParts.length === 0) {
       return message;
     }
 
     if (typeof message === 'string') {
-      return `[requestId=${requestId}] ${message}`;
+      return `[${correlationParts.join(' ')}] ${message}`;
     }
 
     if (message && typeof message === 'object') {
-      return { requestId, ...message };
+      return {
+        ...(requestId ? { requestId } : {}),
+        ...(spanContext?.traceId ? { traceId: spanContext.traceId } : {}),
+        ...(spanContext?.spanId ? { spanId: spanContext.spanId } : {}),
+        ...message,
+      };
     }
 
-    return `[requestId=${requestId}] ${String(message)}`;
+    return `[${correlationParts.join(' ')}] ${String(message)}`;
   }
 
   /**


### PR DESCRIPTION
## Summary
- enrich `AppLoggerService` logs with active OTel `traceId` and `spanId`
- keep existing `requestId` correlation and combine it with trace context when both exist
- include optional `traceId` and `spanId` in standardized error responses from global exception filter
- include trace/span identifiers in exception filter log context for faster root-cause analysis
- update observability telemetry contract to document current trace-log correlation baseline

## Why
Issue #133 requires direct trace-log correlation so an engineer can pivot from a trace to the related logs (and vice versa) during debugging and incident response.

## Validation
- `npm run lint`
- `npm test -- src/common/services/app-logger.service.spec.ts src/common/filters/all-exceptions.filter.spec.ts`
- `npm run build`

## Linked Issues
Closes #133
Refs #125