### PR TITLE
feat(tracing): apply sampling policy per environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,8 +47,17 @@ OTEL_EXPORTER_OTLP_ENDPOINT=
 OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=
 
 # Optional trace sampling ratio [0..1].
-# This will be tuned in Sprint 2 issue #134.
+# Global override for all environments. Prefer env-specific keys below.
 OTEL_TRACES_SAMPLER_ARG=1
+
+# Optional OTel sampler (currently supported: parentbased_traceidratio)
+OTEL_TRACES_SAMPLER=parentbased_traceidratio
+
+# Environment-specific sampling ratios (used when global arg is not set)
+OTEL_TRACES_SAMPLER_ARG_DEVELOPMENT=1
+OTEL_TRACES_SAMPLER_ARG_TEST=1
+OTEL_TRACES_SAMPLER_ARG_STAGING=0.2
+OTEL_TRACES_SAMPLER_ARG_PRODUCTION=0.1
 
 # Optional explicit service version label for traces.
 OTEL_SERVICE_VERSION=0.0.1

--- a/docs/observability/telemetry-contract.md
+++ b/docs/observability/telemetry-contract.md
@@ -101,6 +101,19 @@ Current correlation baseline includes:
   - tracing starts before Nest app bootstrap
   - tracing flush/shutdown runs on process termination signals
 
+### Sampling policy by environment
+
+- Default sampler: `parentbased_traceidratio`
+- Default sampling ratios:
+  - `development`: `1.0`
+  - `test`: `1.0`
+  - `staging`: `0.2`
+  - `production`: `0.1`
+- Configuration precedence:
+  1. `OTEL_TRACES_SAMPLER_ARG` (global override)
+  2. environment-specific arg (`OTEL_TRACES_SAMPLER_ARG_<ENV>`)
+  3. default policy by environment
+
 ## Span instrumentation baseline (Sprint 2)
 
 - HTTP inbound requests are auto-instrumented via Node auto-instrumentations.

--- a/src/observability/otel.config.spec.ts
+++ b/src/observability/otel.config.spec.ts
@@ -18,6 +18,12 @@ describe('OTel config helpers', () => {
     delete process.env.npm_package_version;
     delete process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
     delete process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT;
+    delete process.env.OTEL_TRACES_SAMPLER;
+    delete process.env.OTEL_TRACES_SAMPLER_ARG;
+    delete process.env.OTEL_TRACES_SAMPLER_ARG_DEVELOPMENT;
+    delete process.env.OTEL_TRACES_SAMPLER_ARG_TEST;
+    delete process.env.OTEL_TRACES_SAMPLER_ARG_STAGING;
+    delete process.env.OTEL_TRACES_SAMPLER_ARG_PRODUCTION;
   });
 
   afterAll(() => {
@@ -31,6 +37,45 @@ describe('OTel config helpers', () => {
     expect(config.serviceName).toBe('cardano-backend');
     expect(config.environment).toBe('development');
     expect(config.serviceVersion).toBe('0.0.1');
+    expect(config.sampler).toBe('parentbased_traceidratio');
+    expect(config.samplingRatio).toBe(1);
+  });
+
+  it('uses staging default sampling ratio when no explicit sampler arg', () => {
+    process.env.OBS_ENV = 'staging';
+
+    const config = getOtelConfig();
+    expect(config.samplingRatio).toBe(0.2);
+  });
+
+  it('uses production default sampling ratio when no explicit sampler arg', () => {
+    process.env.OBS_ENV = 'production';
+
+    const config = getOtelConfig();
+    expect(config.samplingRatio).toBe(0.1);
+  });
+
+  it('uses explicit global sampler arg when valid', () => {
+    process.env.OTEL_TRACES_SAMPLER_ARG = '0.33';
+
+    const config = getOtelConfig();
+    expect(config.samplingRatio).toBe(0.33);
+  });
+
+  it('uses env-specific sampler arg when global is missing', () => {
+    process.env.OBS_ENV = 'staging';
+    process.env.OTEL_TRACES_SAMPLER_ARG_STAGING = '0.44';
+
+    const config = getOtelConfig();
+    expect(config.samplingRatio).toBe(0.44);
+  });
+
+  it('falls back to default ratio when explicit sampler arg is invalid', () => {
+    process.env.OBS_ENV = 'production';
+    process.env.OTEL_TRACES_SAMPLER_ARG = 'not-a-number';
+
+    const config = getOtelConfig();
+    expect(config.samplingRatio).toBe(0.1);
   });
 
   it('builds traces endpoint from OTLP base endpoint', () => {

--- a/src/observability/otel.config.ts
+++ b/src/observability/otel.config.ts
@@ -10,9 +10,19 @@ export interface OTelConfig {
   environment: string;
   serviceVersion: string;
   tracesEndpoint?: string;
+  sampler: string;
+  samplingRatio: number;
 }
 
 const TRACE_EXPORT_PATH = '/v1/traces';
+const DEFAULT_SAMPLER = 'parentbased_traceidratio';
+
+const DEFAULT_SAMPLING_RATIO_BY_ENV: Record<string, number> = {
+  development: 1,
+  test: 1,
+  staging: 0.2,
+  production: 0.1,
+};
 
 export function getOtelConfig(): OTelConfig {
   const enabled =
@@ -37,12 +47,18 @@ export function getOtelConfig(): OTelConfig {
     ? normalizeTracesEndpoint(explicitTracesEndpoint, false)
     : normalizeTracesEndpoint(baseOtlpEndpoint, true);
 
+  const sampler =
+    process.env.OTEL_TRACES_SAMPLER?.trim().toLowerCase() || DEFAULT_SAMPLER;
+  const samplingRatio = resolveSamplingRatio(environment);
+
   return {
     enabled,
     serviceName,
     environment,
     serviceVersion,
     tracesEndpoint,
+    sampler,
+    samplingRatio,
   };
 }
 
@@ -74,4 +90,46 @@ export function normalizeTracesEndpoint(
   }
 
   return `${trimmed.replace(/\/$/, '')}${TRACE_EXPORT_PATH}`;
+}
+
+function resolveSamplingRatio(environment: string): number {
+  const explicitRatio = parseRatio(process.env.OTEL_TRACES_SAMPLER_ARG);
+  if (explicitRatio !== undefined) {
+    return explicitRatio;
+  }
+
+  const envSpecificKey = getEnvSpecificSamplerArgKey(environment);
+  const envSpecificRatio = parseRatio(process.env[envSpecificKey]);
+  if (envSpecificRatio !== undefined) {
+    return envSpecificRatio;
+  }
+
+  return DEFAULT_SAMPLING_RATIO_BY_ENV[environment] ?? 1;
+}
+
+function getEnvSpecificSamplerArgKey(environment: string): string {
+  switch (environment) {
+    case 'production':
+      return 'OTEL_TRACES_SAMPLER_ARG_PRODUCTION';
+    case 'staging':
+      return 'OTEL_TRACES_SAMPLER_ARG_STAGING';
+    case 'test':
+      return 'OTEL_TRACES_SAMPLER_ARG_TEST';
+    case 'development':
+    default:
+      return 'OTEL_TRACES_SAMPLER_ARG_DEVELOPMENT';
+  }
+}
+
+function parseRatio(value: string | undefined): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) {
+    return undefined;
+  }
+
+  return parsed;
 }

--- a/src/observability/otel.ts
+++ b/src/observability/otel.ts
@@ -31,7 +31,7 @@ export function setupOpenTelemetry(): void {
     url: config.tracesEndpoint,
   });
 
-  const sampler = buildSampler();
+  const sampler = buildSampler(config.sampler, config.samplingRatio);
   const spanProcessor = new BatchSpanProcessor(traceExporter);
   const resource = new Resource(getOtelResourceAttributes(config));
 
@@ -65,11 +65,8 @@ export async function shutdownOpenTelemetry(): Promise<void> {
   await sdk.shutdown();
 }
 
-function buildSampler(): Sampler {
-  const ratioRaw = process.env.OTEL_TRACES_SAMPLER_ARG || '1';
-  const ratio = Number(ratioRaw);
-
-  if (!Number.isFinite(ratio) || ratio < 0 || ratio > 1) {
+function buildSampler(samplerName: string, ratio: number): Sampler {
+  if (samplerName !== 'parentbased_traceidratio') {
     return new ParentBasedSampler({
       root: new TraceIdRatioBasedSampler(1),
     });


### PR DESCRIPTION
## Summary
- implement environment-based sampling policy for OpenTelemetry tracing
- add configuration precedence for sampler ratio overrides (global, env-specific, defaults)
- keep default sampler as `parentbased_traceidratio` with practical defaults for development/staging/production
- document sampling policy in `.env.example` and telemetry contract
- add tests for sampling policy resolution and fallback behavior

## Why
Issue #134 requires sampling to be configurable by environment so production tracing overhead remains controlled while preserving enough trace signal for debugging.

## Validation
- `npm run lint`
- `npm test -- src/observability/otel.config.spec.ts`
- `npm run build`

## Linked Issues
Closes #134
Refs #125