### PR TITLE
feat(logging): implement structured JSON logging schema

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,12 @@ LOG_TIMESTAMP=true
 # Enable/disable colors in logs (default: true for development, false for production)
 LOG_COLORS=true
 
+# Log output format: json | text
+LOG_FORMAT=json
+
+# Include stack trace in error logs (recommended true in staging/dev, false in production)
+LOG_INCLUDE_STACK=false
+
 # ==========================================================================
 # OPENTELEMETRY TRACING
 # ==========================================================================

--- a/docs/observability/telemetry-contract.md
+++ b/docs/observability/telemetry-contract.md
@@ -87,6 +87,31 @@ Current correlation baseline includes:
 - logger output enriched with active span `traceId` and `spanId`
 - standardized error responses include optional `traceId` and `spanId` when span context exists
 
+### Structured JSON logging schema
+
+Baseline structured fields:
+
+- `timestamp`
+- `level`
+- `service`
+- `env`
+- `message`
+- `context` (when available)
+- `requestId` (when available)
+- `traceId` / `spanId` (when available)
+
+HTTP request log fields (when using `logHttpRequest`):
+
+- `method`
+- `route`
+- `statusCode`
+- `durationMs`
+
+Controls:
+
+- `LOG_FORMAT` (`json` default)
+- `LOG_INCLUDE_STACK` (`false` recommended in production)
+
 ## Tracing bootstrap contract (Sprint 2 start)
 
 - OpenTelemetry SDK bootstrap is controlled by `OTEL_ENABLED`

--- a/src/common/services/app-logger.service.spec.ts
+++ b/src/common/services/app-logger.service.spec.ts
@@ -1,27 +1,23 @@
-/*
- * --------------------------------------------------------------------------
- * File: app-logger.service.spec.ts
- * Project: car-dano-backend
- * --------------------------------------------------------------------------
- * Tests for AppLoggerService — log level filtering, structured logging,
- * HTTP request logging, database operation logging, and level check.
- * --------------------------------------------------------------------------
- */
-
 import { Test } from '@nestjs/testing';
 import { AppLoggerService } from './app-logger.service';
 import { ConfigService } from '@nestjs/config';
 import { trace } from '@opentelemetry/api';
 import { RequestContext } from '../request-context';
 
-function buildModule(logLevel: string, timestamp = true, colors = true) {
+function buildModule(logLevel: string, extras: Record<string, any> = {}) {
+  const configMap: Record<string, any> = {
+    LOG_LEVEL: logLevel,
+    LOG_FORMAT: 'json',
+    OBS_SERVICE_NAME: 'cardano-backend',
+    OBS_ENV: 'staging',
+    LOG_INCLUDE_STACK: 'true',
+    ...extras,
+  };
+
   const mockConfigService = {
-    get: jest.fn((key: string, defaultValue?: any) => {
-      if (key === 'LOG_LEVEL') return logLevel;
-      if (key === 'LOG_TIMESTAMP') return timestamp;
-      if (key === 'LOG_COLORS') return colors;
-      return defaultValue;
-    }),
+    get: jest.fn((key: string, defaultValue?: any) =>
+      key in configMap ? configMap[key] : defaultValue,
+    ),
   };
 
   return Test.createTestingModule({
@@ -32,428 +28,121 @@ function buildModule(logLevel: string, timestamp = true, colors = true) {
   }).compile();
 }
 
+function parseJsonLog(payload: string): Record<string, any> {
+  return JSON.parse(payload);
+}
+
 describe('AppLoggerService', () => {
-  let service: AppLoggerService;
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
 
-  beforeEach(async () => {
+  it('should emit JSON log with baseline fields', async () => {
     const module = await buildModule('info');
-    service = await module.resolve(AppLoggerService);
+    const logger = await module.resolve(AppLoggerService);
+    const superLogSpy = jest
+      .spyOn(Object.getPrototypeOf(Object.getPrototypeOf(logger)), 'log')
+      .mockImplementation(() => {});
+
+    logger.log('hello world', 'Bootstrap');
+
+    const payload = parseJsonLog(superLogSpy.mock.calls[0][0] as string);
+    expect(payload.level).toBe('log');
+    expect(payload.message).toBe('hello world');
+    expect(payload.service).toBe('cardano-backend');
+    expect(payload.env).toBe('staging');
+    expect(payload.context).toBe('Bootstrap');
+    expect(payload.timestamp).toBeDefined();
   });
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
+  it('should include requestId traceId spanId when available', async () => {
+    const module = await buildModule('info');
+    const logger = await module.resolve(AppLoggerService);
+    const superLogSpy = jest
+      .spyOn(Object.getPrototypeOf(Object.getPrototypeOf(logger)), 'log')
+      .mockImplementation(() => {});
+
+    jest.spyOn(trace, 'getActiveSpan').mockReturnValue({
+      spanContext: () => ({
+        traceId: '0123456789abcdef0123456789abcdef',
+        spanId: '0123456789abcdef',
+        traceFlags: 1,
+      }),
+    } as any);
+
+    RequestContext.run({ requestId: 'req-123' }, () => {
+      logger.log('correlated log');
+    });
+
+    const payload = parseJsonLog(superLogSpy.mock.calls[0][0] as string);
+    expect(payload.requestId).toBe('req-123');
+    expect(payload.traceId).toBe('0123456789abcdef0123456789abcdef');
+    expect(payload.spanId).toBe('0123456789abcdef');
   });
 
-  // ---------------------------------------------------------------------------
-  describe('initializeConfig — log level hierarchy', () => {
-    it('should enable only error for level "error"', async () => {
-      const module = await buildModule('error');
-      const s = await module.resolve(AppLoggerService);
-      expect(s.isLevelEnabled('error')).toBe(true);
-      expect(s.isLevelEnabled('warn')).toBe(false);
-      expect(s.isLevelEnabled('log')).toBe(false);
-    });
+  it('should include http request fields in structured payload', async () => {
+    const module = await buildModule('info');
+    const logger = await module.resolve(AppLoggerService);
+    const superWarnSpy = jest
+      .spyOn(Object.getPrototypeOf(Object.getPrototypeOf(logger)), 'warn')
+      .mockImplementation(() => {});
 
-    it('should enable warn and error for level "warn"', async () => {
-      const module = await buildModule('warn');
-      const s = await module.resolve(AppLoggerService);
-      expect(s.isLevelEnabled('warn')).toBe(true);
-      expect(s.isLevelEnabled('error')).toBe(true);
-      expect(s.isLevelEnabled('log')).toBe(false);
-    });
+    logger.logHttpRequest('GET', '/api/v1/inspections/:id', 500, 81, 'HTTP');
 
-    it('should enable log, warn, error for level "info"', async () => {
-      const module = await buildModule('info');
-      const s = await module.resolve(AppLoggerService);
-      expect(s.isLevelEnabled('log')).toBe(true);
-      expect(s.isLevelEnabled('warn')).toBe(true);
-      expect(s.isLevelEnabled('error')).toBe(true);
-      expect(s.isLevelEnabled('debug')).toBe(false);
-    });
-
-    it('should enable debug, log, warn, error for level "debug"', async () => {
-      const module = await buildModule('debug');
-      const s = await module.resolve(AppLoggerService);
-      expect(s.isLevelEnabled('debug')).toBe(true);
-      expect(s.isLevelEnabled('log')).toBe(true);
-      expect(s.isLevelEnabled('warn')).toBe(true);
-      expect(s.isLevelEnabled('error')).toBe(true);
-      expect(s.isLevelEnabled('verbose')).toBe(false);
-    });
-
-    it('should enable all levels for "verbose"', async () => {
-      const module = await buildModule('verbose');
-      const s = await module.resolve(AppLoggerService);
-      expect(s.isLevelEnabled('verbose')).toBe(true);
-      expect(s.isLevelEnabled('debug')).toBe(true);
-      expect(s.isLevelEnabled('log')).toBe(true);
-      expect(s.isLevelEnabled('warn')).toBe(true);
-      expect(s.isLevelEnabled('error')).toBe(true);
-    });
-
-    it('should fall into default branch for unknown level and enable error/warn/log', async () => {
-      const module = await buildModule('unknown_level');
-      const s = await module.resolve(AppLoggerService);
-      expect(s.isLevelEnabled('error')).toBe(true);
-      expect(s.isLevelEnabled('warn')).toBe(true);
-      expect(s.isLevelEnabled('log')).toBe(true);
-      expect(s.isLevelEnabled('debug')).toBe(false);
-    });
-
-    it('should handle uppercase log levels case-insensitively', async () => {
-      const module = await buildModule('INFO');
-      const s = await module.resolve(AppLoggerService);
-      expect(s.isLevelEnabled('log')).toBe(true);
-    });
+    const payload = parseJsonLog(superWarnSpy.mock.calls[0][0] as string);
+    expect(payload.message).toBe('http_request');
+    expect(payload.method).toBe('GET');
+    expect(payload.route).toBe('/api/v1/inspections/:id');
+    expect(payload.statusCode).toBe(500);
+    expect(payload.durationMs).toBe(81);
+    expect(payload.level).toBe('warn');
   });
 
-  // ---------------------------------------------------------------------------
-  describe('setContext', () => {
-    it('should set the context property', () => {
-      service.setContext('TestContext');
-      expect((service as any).context).toBe('TestContext');
-    });
+  it('should include metadata via logWithMetadata', async () => {
+    const module = await buildModule('info');
+    const logger = await module.resolve(AppLoggerService);
+    const superLogSpy = jest
+      .spyOn(Object.getPrototypeOf(Object.getPrototypeOf(logger)), 'log')
+      .mockImplementation(() => {});
+
+    logger.logWithMetadata(
+      'log',
+      'meta_event',
+      { foo: 'bar', count: 2 },
+      'Meta',
+    );
+
+    const payload = parseJsonLog(superLogSpy.mock.calls[0][0] as string);
+    expect(payload.message).toBe('meta_event');
+    expect(payload.foo).toBe('bar');
+    expect(payload.count).toBe(2);
+    expect(payload.context).toBe('Meta');
   });
 
-  // ---------------------------------------------------------------------------
-  describe('log', () => {
-    it('should call super.log when "log" level is enabled', async () => {
-      const module = await buildModule('info');
-      const s = await module.resolve(AppLoggerService);
-      const spy = jest
-        .spyOn(Object.getPrototypeOf(Object.getPrototypeOf(s)), 'log')
-        .mockImplementation(() => {});
-      s.log('test message');
-      expect(spy).toHaveBeenCalledWith('test message', undefined);
-      spy.mockRestore();
-    });
+  it('should include stack only when LOG_INCLUDE_STACK=true', async () => {
+    const module = await buildModule('error', { LOG_INCLUDE_STACK: 'true' });
+    const logger = await module.resolve(AppLoggerService);
+    const superErrorSpy = jest
+      .spyOn(Object.getPrototypeOf(Object.getPrototypeOf(logger)), 'error')
+      .mockImplementation(() => {});
 
-    it('should NOT call super.log when "log" level is disabled', async () => {
-      const module = await buildModule('error');
-      const s = await module.resolve(AppLoggerService);
-      const spy = jest
-        .spyOn(Object.getPrototypeOf(Object.getPrototypeOf(s)), 'log')
-        .mockImplementation(() => {});
-      s.log('silent message');
-      expect(spy).not.toHaveBeenCalled();
-      spy.mockRestore();
-    });
+    logger.error('failed', 'stack-value', 'ErrCtx');
 
-    it('should pass context when provided', async () => {
-      const module = await buildModule('info');
-      const s = await module.resolve(AppLoggerService);
-      const spy = jest
-        .spyOn(Object.getPrototypeOf(Object.getPrototypeOf(s)), 'log')
-        .mockImplementation(() => {});
-      s.log('msg', 'MyContext');
-      expect(spy).toHaveBeenCalledWith('msg', 'MyContext');
-      spy.mockRestore();
-    });
-
-    it('should include requestId from request context in log message', async () => {
-      const module = await buildModule('info');
-      const s = await module.resolve(AppLoggerService);
-      const spy = jest
-        .spyOn(Object.getPrototypeOf(Object.getPrototypeOf(s)), 'log')
-        .mockImplementation(() => {});
-
-      RequestContext.run({ requestId: 'req-ctx-1' }, () => {
-        s.log('test message');
-      });
-
-      expect(spy).toHaveBeenCalledWith(
-        '[requestId=req-ctx-1] test message',
-        undefined,
-      );
-      spy.mockRestore();
-    });
-
-    it('should include traceId and spanId from active span context', async () => {
-      const module = await buildModule('info');
-      const s = await module.resolve(AppLoggerService);
-      const spy = jest
-        .spyOn(Object.getPrototypeOf(Object.getPrototypeOf(s)), 'log')
-        .mockImplementation(() => {});
-
-      const activeSpanSpy = jest.spyOn(trace, 'getActiveSpan').mockReturnValue({
-        spanContext: () => ({
-          traceId: '0123456789abcdef0123456789abcdef',
-          spanId: '0123456789abcdef',
-          traceFlags: 1,
-        }),
-      } as any);
-
-      s.log('trace message');
-
-      const loggedMessage = spy.mock.calls[0][0] as string;
-      expect(loggedMessage).toContain('traceId=');
-      expect(loggedMessage).toContain('spanId=');
-      expect(loggedMessage).toContain('trace message');
-      activeSpanSpy.mockRestore();
-      spy.mockRestore();
-    });
-
-    it('should include both requestId and trace context when both available', async () => {
-      const module = await buildModule('info');
-      const s = await module.resolve(AppLoggerService);
-      const spy = jest
-        .spyOn(Object.getPrototypeOf(Object.getPrototypeOf(s)), 'log')
-        .mockImplementation(() => {});
-
-      const activeSpanSpy = jest.spyOn(trace, 'getActiveSpan').mockReturnValue({
-        spanContext: () => ({
-          traceId: 'abcdef0123456789abcdef0123456789',
-          spanId: 'abcdef0123456789',
-          traceFlags: 1,
-        }),
-      } as any);
-
-      RequestContext.run({ requestId: 'req-and-trace' }, () => {
-        s.log('combined message');
-      });
-
-      const loggedMessage = spy.mock.calls[0][0] as string;
-      expect(loggedMessage).toContain('requestId=req-and-trace');
-      expect(loggedMessage).toContain('traceId=');
-      expect(loggedMessage).toContain('spanId=');
-      activeSpanSpy.mockRestore();
-      spy.mockRestore();
-    });
+    const payload = parseJsonLog(superErrorSpy.mock.calls[0][0] as string);
+    expect(payload.stack).toBe('stack-value');
+    expect(payload.context).toBe('ErrCtx');
   });
 
-  // ---------------------------------------------------------------------------
-  describe('error', () => {
-    it('should call super.error when "error" level is enabled', async () => {
-      const module = await buildModule('error');
-      const s = await module.resolve(AppLoggerService);
-      const spy = jest
-        .spyOn(Object.getPrototypeOf(Object.getPrototypeOf(s)), 'error')
-        .mockImplementation(() => {});
-      s.error('something broke', 'stack trace');
-      expect(spy).toHaveBeenCalled();
-      spy.mockRestore();
-    });
+  it('should skip stack when LOG_INCLUDE_STACK=false', async () => {
+    const module = await buildModule('error', { LOG_INCLUDE_STACK: 'false' });
+    const logger = await module.resolve(AppLoggerService);
+    const superErrorSpy = jest
+      .spyOn(Object.getPrototypeOf(Object.getPrototypeOf(logger)), 'error')
+      .mockImplementation(() => {});
 
-    it('should NOT call super.error when disabled (impossible since error is always in default, test via direct set)', async () => {
-      const module = await buildModule('info');
-      const s = await module.resolve(AppLoggerService);
-      // Manually empty enabledLevels to simulate disabled error
-      (s as any).enabledLevels = new Set<string>();
-      const spy = jest
-        .spyOn(Object.getPrototypeOf(Object.getPrototypeOf(s)), 'error')
-        .mockImplementation(() => {});
-      s.error('silent error');
-      expect(spy).not.toHaveBeenCalled();
-      spy.mockRestore();
-    });
-  });
+    logger.error('failed', 'stack-value', 'ErrCtx');
 
-  // ---------------------------------------------------------------------------
-  describe('warn', () => {
-    it('should call super.warn when level is enabled', async () => {
-      const module = await buildModule('warn');
-      const s = await module.resolve(AppLoggerService);
-      const spy = jest
-        .spyOn(Object.getPrototypeOf(Object.getPrototypeOf(s)), 'warn')
-        .mockImplementation(() => {});
-      s.warn('warning msg');
-      expect(spy).toHaveBeenCalledWith('warning msg', undefined);
-      spy.mockRestore();
-    });
-
-    it('should NOT call super.warn when disabled', async () => {
-      const module = await buildModule('error');
-      const s = await module.resolve(AppLoggerService);
-      const spy = jest
-        .spyOn(Object.getPrototypeOf(Object.getPrototypeOf(s)), 'warn')
-        .mockImplementation(() => {});
-      s.warn('suppressed warning');
-      expect(spy).not.toHaveBeenCalled();
-      spy.mockRestore();
-    });
-  });
-
-  // ---------------------------------------------------------------------------
-  describe('debug', () => {
-    it('should call super.debug when level is enabled', async () => {
-      const module = await buildModule('debug');
-      const s = await module.resolve(AppLoggerService);
-      const spy = jest
-        .spyOn(Object.getPrototypeOf(Object.getPrototypeOf(s)), 'debug')
-        .mockImplementation(() => {});
-      s.debug('debug msg');
-      expect(spy).toHaveBeenCalledWith('debug msg', undefined);
-      spy.mockRestore();
-    });
-
-    it('should NOT call super.debug when level is info', async () => {
-      const module = await buildModule('info');
-      const s = await module.resolve(AppLoggerService);
-      const spy = jest
-        .spyOn(Object.getPrototypeOf(Object.getPrototypeOf(s)), 'debug')
-        .mockImplementation(() => {});
-      s.debug('suppressed debug');
-      expect(spy).not.toHaveBeenCalled();
-      spy.mockRestore();
-    });
-  });
-
-  // ---------------------------------------------------------------------------
-  describe('verbose', () => {
-    it('should call super.verbose when level is enabled', async () => {
-      const module = await buildModule('verbose');
-      const s = await module.resolve(AppLoggerService);
-      const spy = jest
-        .spyOn(Object.getPrototypeOf(Object.getPrototypeOf(s)), 'verbose')
-        .mockImplementation(() => {});
-      s.verbose('verbose msg');
-      expect(spy).toHaveBeenCalledWith('verbose msg', undefined);
-      spy.mockRestore();
-    });
-
-    it('should NOT call super.verbose when level is debug', async () => {
-      const module = await buildModule('debug');
-      const s = await module.resolve(AppLoggerService);
-      const spy = jest
-        .spyOn(Object.getPrototypeOf(Object.getPrototypeOf(s)), 'verbose')
-        .mockImplementation(() => {});
-      s.verbose('suppressed verbose');
-      expect(spy).not.toHaveBeenCalled();
-      spy.mockRestore();
-    });
-  });
-
-  // ---------------------------------------------------------------------------
-  describe('logWithMetadata', () => {
-    it('should return early when level is not enabled', async () => {
-      const module = await buildModule('error');
-      const s = await module.resolve(AppLoggerService);
-      const logSpy = jest.spyOn(s, 'log');
-      s.logWithMetadata('log', 'suppressed', { key: 'val' });
-      expect(logSpy).not.toHaveBeenCalled();
-    });
-
-    it('should call the appropriate method with stringified metadata', async () => {
-      const module = await buildModule('info');
-      const s = await module.resolve(AppLoggerService);
-      const logSpy = jest.spyOn(s, 'log').mockImplementation(() => {});
-      s.logWithMetadata('log', 'msg', { requestId: '123' });
-      expect(logSpy).toHaveBeenCalledWith('msg {"requestId":"123"}', undefined);
-    });
-
-    it('should call the method with plain message when no metadata', async () => {
-      const module = await buildModule('info');
-      const s = await module.resolve(AppLoggerService);
-      const logSpy = jest.spyOn(s, 'log').mockImplementation(() => {});
-      s.logWithMetadata('log', 'plain msg');
-      expect(logSpy).toHaveBeenCalledWith('plain msg', undefined);
-    });
-
-    it('should use custom context when provided', async () => {
-      const module = await buildModule('warn');
-      const s = await module.resolve(AppLoggerService);
-      const warnSpy = jest.spyOn(s, 'warn').mockImplementation(() => {});
-      s.logWithMetadata('warn', 'warn msg', undefined, 'CustomCtx');
-      expect(warnSpy).toHaveBeenCalledWith('warn msg', 'CustomCtx');
-    });
-
-    it('should use error level correctly', async () => {
-      const module = await buildModule('error');
-      const s = await module.resolve(AppLoggerService);
-      const errorSpy = jest.spyOn(s, 'error').mockImplementation(() => {});
-      s.logWithMetadata('error', 'error msg', { code: 500 });
-      expect(errorSpy).toHaveBeenCalledWith(
-        'error msg {"code":500}',
-        undefined,
-      );
-    });
-  });
-
-  // ---------------------------------------------------------------------------
-  describe('logHttpRequest', () => {
-    it('should call warn for status >= 400', async () => {
-      const module = await buildModule('info');
-      const s = await module.resolve(AppLoggerService);
-      const warnSpy = jest.spyOn(s, 'warn').mockImplementation(() => {});
-      s.logHttpRequest('GET', '/api/test', 404, 30);
-      expect(warnSpy).toHaveBeenCalledWith('GET /api/test 404 - 30ms', 'HTTP');
-    });
-
-    it('should call log for status < 400', async () => {
-      const module = await buildModule('info');
-      const s = await module.resolve(AppLoggerService);
-      const logSpy = jest.spyOn(s, 'log').mockImplementation(() => {});
-      s.logHttpRequest('POST', '/api/data', 201, 100);
-      expect(logSpy).toHaveBeenCalledWith('POST /api/data 201 - 100ms', 'HTTP');
-    });
-
-    it('should call warn for status 500', async () => {
-      const module = await buildModule('info');
-      const s = await module.resolve(AppLoggerService);
-      const warnSpy = jest.spyOn(s, 'warn').mockImplementation(() => {});
-      s.logHttpRequest('DELETE', '/api/item/1', 500, 5);
-      expect(warnSpy).toHaveBeenCalledWith(
-        'DELETE /api/item/1 500 - 5ms',
-        'HTTP',
-      );
-    });
-
-    it('should use provided context instead of default HTTP', async () => {
-      const module = await buildModule('info');
-      const s = await module.resolve(AppLoggerService);
-      const logSpy = jest.spyOn(s, 'log').mockImplementation(() => {});
-      s.logHttpRequest('GET', '/health', 200, 2, 'HealthContext');
-      expect(logSpy).toHaveBeenCalledWith(
-        'GET /health 200 - 2ms',
-        'HealthContext',
-      );
-    });
-  });
-
-  // ---------------------------------------------------------------------------
-  describe('logDatabaseOperation', () => {
-    it('should call debug with formatted message', async () => {
-      const module = await buildModule('debug');
-      const s = await module.resolve(AppLoggerService);
-      const debugSpy = jest.spyOn(s, 'debug').mockImplementation(() => {});
-      s.logDatabaseOperation('SELECT', 'users', 12);
-      expect(debugSpy).toHaveBeenCalledWith(
-        'DB SELECT on users - 12ms',
-        'Database',
-      );
-    });
-
-    it('should use custom context when provided', async () => {
-      const module = await buildModule('debug');
-      const s = await module.resolve(AppLoggerService);
-      const debugSpy = jest.spyOn(s, 'debug').mockImplementation(() => {});
-      s.logDatabaseOperation('INSERT', 'inspection', 45, 'InspectionRepo');
-      expect(debugSpy).toHaveBeenCalledWith(
-        'DB INSERT on inspection - 45ms',
-        'InspectionRepo',
-      );
-    });
-
-    it('should not call debug when level is info (debug disabled)', async () => {
-      const module = await buildModule('info');
-      const s = await module.resolve(AppLoggerService);
-      jest.spyOn(s, 'debug').mockImplementation(() => {});
-      s.logDatabaseOperation('UPDATE', 'photo', 20);
-      // debug spy is on the service-level debug method which checks enabledLevels
-      // Since info doesn't include debug, the underlying super.debug won't be called
-      // but our spy is at service level — need to verify via isLevelEnabled
-      expect(s.isLevelEnabled('debug')).toBe(false);
-    });
-  });
-
-  // ---------------------------------------------------------------------------
-  describe('isLevelEnabled', () => {
-    it('should return false for unlisted level', () => {
-      expect(service.isLevelEnabled('trace')).toBe(false);
-    });
-
-    it('should return true for log at info level', () => {
-      expect(service.isLevelEnabled('log')).toBe(true);
-    });
+    const payload = parseJsonLog(superErrorSpy.mock.calls[0][0] as string);
+    expect(payload.stack).toBeUndefined();
   });
 });

--- a/src/common/services/app-logger.service.ts
+++ b/src/common/services/app-logger.service.ts
@@ -14,11 +14,15 @@ import { ConfigService } from '@nestjs/config';
 import { trace } from '@opentelemetry/api';
 import { RequestContext } from '../request-context';
 
+type LogLevelName = 'log' | 'error' | 'warn' | 'debug' | 'verbose';
+
 @Injectable({ scope: Scope.TRANSIENT })
 export class AppLoggerService extends Logger implements LoggerService {
   private enabledLevels!: Set<string>;
-  private enableTimestamp!: boolean;
-  private enableColors!: boolean;
+  private serviceName!: string;
+  private environment!: string;
+  private useJsonFormat!: boolean;
+  private includeStack!: boolean;
 
   constructor(private configService: ConfigService) {
     super();
@@ -27,11 +31,18 @@ export class AppLoggerService extends Logger implements LoggerService {
 
   private initializeConfig() {
     const logLevel = this.configService.get<string>('LOG_LEVEL', 'info');
-    this.enableTimestamp = this.configService.get<boolean>(
-      'LOG_TIMESTAMP',
-      true,
-    );
-    this.enableColors = this.configService.get<boolean>('LOG_COLORS', true);
+    this.serviceName =
+      this.configService.get<string>('OBS_SERVICE_NAME') || 'cardano-backend';
+    this.environment =
+      this.configService.get<string>('OBS_ENV') ||
+      this.configService.get<string>('NODE_ENV', 'development');
+    this.useJsonFormat =
+      (
+        this.configService.get<string>('LOG_FORMAT', 'json') || 'json'
+      ).toLowerCase() === 'json';
+    this.includeStack =
+      (this.configService.get<string>('LOG_INCLUDE_STACK') ||
+        (this.environment === 'production' ? 'false' : 'true')) === 'true';
 
     // Set enabled levels based on configuration
     this.enabledLevels = new Set();
@@ -81,7 +92,7 @@ export class AppLoggerService extends Logger implements LoggerService {
    */
   log(message: any, context?: string) {
     if (this.enabledLevels.has('log')) {
-      super.log(this.withRequestId(message), context || this.context);
+      super.log(this.formatLog('log', message, context || this.context));
     }
   }
 
@@ -90,7 +101,11 @@ export class AppLoggerService extends Logger implements LoggerService {
    */
   error(message: any, trace?: string, context?: string) {
     if (this.enabledLevels.has('error')) {
-      super.error(this.withRequestId(message), trace, context || this.context);
+      super.error(
+        this.formatLog('error', message, context || this.context, {
+          ...(trace && this.includeStack ? { stack: trace } : {}),
+        }),
+      );
     }
   }
 
@@ -99,7 +114,7 @@ export class AppLoggerService extends Logger implements LoggerService {
    */
   warn(message: any, context?: string) {
     if (this.enabledLevels.has('warn')) {
-      super.warn(this.withRequestId(message), context || this.context);
+      super.warn(this.formatLog('warn', message, context || this.context));
     }
   }
 
@@ -108,7 +123,7 @@ export class AppLoggerService extends Logger implements LoggerService {
    */
   debug(message: any, context?: string) {
     if (this.enabledLevels.has('debug')) {
-      super.debug(this.withRequestId(message), context || this.context);
+      super.debug(this.formatLog('debug', message, context || this.context));
     }
   }
 
@@ -117,43 +132,70 @@ export class AppLoggerService extends Logger implements LoggerService {
    */
   verbose(message: any, context?: string) {
     if (this.enabledLevels.has('verbose')) {
-      super.verbose(this.withRequestId(message), context || this.context);
+      super.verbose(
+        this.formatLog('verbose', message, context || this.context),
+      );
     }
   }
 
-  private withRequestId(message: any): any {
+  private buildCorrelationContext(): Record<string, string> {
     const requestId = RequestContext.getRequestId();
     const spanContext = trace.getActiveSpan()?.spanContext();
 
-    const correlationParts: string[] = [];
-    if (requestId) {
-      correlationParts.push(`requestId=${requestId}`);
-    }
-    if (spanContext?.traceId) {
-      correlationParts.push(`traceId=${spanContext.traceId}`);
-    }
-    if (spanContext?.spanId) {
-      correlationParts.push(`spanId=${spanContext.spanId}`);
+    return {
+      ...(requestId ? { requestId } : {}),
+      ...(spanContext?.traceId ? { traceId: spanContext.traceId } : {}),
+      ...(spanContext?.spanId ? { spanId: spanContext.spanId } : {}),
+    };
+  }
+
+  private formatLog(
+    level: LogLevelName,
+    message: any,
+    context?: string,
+    metadata?: Record<string, unknown>,
+  ): string {
+    const correlation = this.buildCorrelationContext();
+    const payload = {
+      timestamp: new Date().toISOString(),
+      level,
+      service: this.serviceName,
+      env: this.environment,
+      ...(context ? { context } : {}),
+      message: this.serializeMessage(message),
+      ...correlation,
+      ...(metadata || {}),
+    } as Record<string, unknown>;
+
+    if (message instanceof Error && this.includeStack && message.stack) {
+      payload.stack = message.stack;
     }
 
-    if (correlationParts.length === 0) {
+    if (!this.useJsonFormat) {
+      return String(payload.message);
+    }
+
+    return JSON.stringify(payload);
+  }
+
+  private serializeMessage(message: unknown): string {
+    if (typeof message === 'string') {
       return message;
     }
 
-    if (typeof message === 'string') {
-      return `[${correlationParts.join(' ')}] ${message}`;
+    if (message instanceof Error) {
+      return message.message;
     }
 
-    if (message && typeof message === 'object') {
-      return {
-        ...(requestId ? { requestId } : {}),
-        ...(spanContext?.traceId ? { traceId: spanContext.traceId } : {}),
-        ...(spanContext?.spanId ? { spanId: spanContext.spanId } : {}),
-        ...message,
-      };
+    if (typeof message === 'object' && message !== null) {
+      try {
+        return JSON.stringify(message);
+      } catch {
+        return '[unserializable-object]';
+      }
     }
 
-    return `[${correlationParts.join(' ')}] ${String(message)}`;
+    return String(message);
   }
 
   /**
@@ -169,11 +211,34 @@ export class AppLoggerService extends Logger implements LoggerService {
       return;
     }
 
-    const logMessage = metadata
-      ? `${message} ${JSON.stringify(metadata)}`
-      : message;
+    const formatted = this.formatLog(
+      level,
+      message,
+      context || this.context,
+      metadata,
+    );
 
-    this[level](logMessage, context || this.context);
+    if (level === 'error') {
+      super.error(formatted);
+      return;
+    }
+
+    if (level === 'warn') {
+      super.warn(formatted);
+      return;
+    }
+
+    if (level === 'debug') {
+      super.debug(formatted);
+      return;
+    }
+
+    if (level === 'verbose') {
+      super.verbose(formatted);
+      return;
+    }
+
+    super.log(formatted);
   }
 
   /**
@@ -186,12 +251,23 @@ export class AppLoggerService extends Logger implements LoggerService {
     responseTime: number,
     context?: string,
   ) {
-    const message = `${method} ${url} ${statusCode} - ${responseTime}ms`;
+    const level = statusCode >= 400 ? 'warn' : 'log';
+    const logMessage = this.formatLog(
+      level,
+      'http_request',
+      context || 'HTTP',
+      {
+        method,
+        route: url,
+        statusCode,
+        durationMs: responseTime,
+      },
+    );
 
     if (statusCode >= 400) {
-      this.warn(message, context || 'HTTP');
+      super.warn(logMessage);
     } else {
-      this.log(message, context || 'HTTP');
+      super.log(logMessage);
     }
   }
 
@@ -204,9 +280,16 @@ export class AppLoggerService extends Logger implements LoggerService {
     duration: number,
     context?: string,
   ) {
-    this.debug(
-      `DB ${operation} on ${table} - ${duration}ms`,
-      context || 'Database',
+    if (!this.enabledLevels.has('debug')) {
+      return;
+    }
+
+    super.debug(
+      this.formatLog('debug', 'database_operation', context || 'Database', {
+        operation,
+        table,
+        durationMs: duration,
+      }),
     );
   }
 


### PR DESCRIPTION
## Summary
- refactor `AppLoggerService` to emit machine-parseable JSON logs by default
- include baseline schema fields: `timestamp`, `level`, `service`, `env`, `message`, `context`
- include correlation fields when available: `requestId`, `traceId`, `spanId`
- add HTTP request structured fields: `method`, `route`, `statusCode`, `durationMs`
- add logger controls for format and stack behavior (`LOG_FORMAT`, `LOG_INCLUDE_STACK`)
- update telemetry contract and logger tests for JSON schema expectations

## Why
Issue #129 requires standardized structured logs so Loki ingestion and operational querying work consistently across environments.

## Validation
- `npm run lint`
- `npm test -- src/common/services/app-logger.service.spec.ts src/common/filters/all-exceptions.filter.spec.ts`
- `npm run build`

## Linked Issues
Closes #129
Refs #123
Refs #135